### PR TITLE
Refactor/#23 각 엔티티가 Setter 대신 SuperBuilder를 사용하도록 수정

### DIFF
--- a/src/main/java/com/_1/spring_rest_api/config/SecurityConfig.java
+++ b/src/main/java/com/_1/spring_rest_api/config/SecurityConfig.java
@@ -28,8 +28,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/login", "/oauth2/**", "/api/public/auth/**", "/error", "/swagger-ui/**").permitAll()
-                        .anyRequest().authenticated()
+                                .anyRequest().permitAll()
+                        //.requestMatchers("/", "/login", "/oauth2/**", "/api/public/auth/**", "/error", "/swagger-ui/**").permitAll()
+                        //.anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .successHandler(oAuth2SuccessHandler)

--- a/src/main/java/com/_1/spring_rest_api/entity/Course.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Course.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 @Entity
 @Table(name = "COURSE")
 @Getter
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class Course extends BaseTimeEntity {

--- a/src/main/java/com/_1/spring_rest_api/entity/Course.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Course.java
@@ -6,6 +6,7 @@ import com._1.spring_rest_api.api.dto.WeekResponse;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +15,7 @@ import java.util.stream.Collectors;
 @Entity
 @Table(name = "COURSE")
 @Getter
-@Builder(toBuilder = true)
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Course extends BaseTimeEntity {
@@ -36,6 +37,7 @@ public class Course extends BaseTimeEntity {
 
     @Setter
     @OneToMany(mappedBy = "course")
+    @Builder.Default
     private List<Week> weeks = new ArrayList<>();
 
     public Course(User creator, String title, String description) {

--- a/src/main/java/com/_1/spring_rest_api/entity/CustomQuiz.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/CustomQuiz.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +14,7 @@ import java.util.List;
 @Entity
 @Table(name = "CUSTOM_QUIZ")
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class CustomQuiz extends BaseTimeEntity {
@@ -40,11 +41,14 @@ public class CustomQuiz extends BaseTimeEntity {
     private String quizType;
 
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<QuizQuestionMapping> quizQuestionMappings = new ArrayList<>();
 
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<QuizSession> quizSessions = new ArrayList<>();
 
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<QuizWeekMapping> quizWeekMappings = new ArrayList<>();
 }

--- a/src/main/java/com/_1/spring_rest_api/entity/CustomQuiz.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/CustomQuiz.java
@@ -2,6 +2,8 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +13,8 @@ import java.util.List;
 @Entity
 @Table(name = "CUSTOM_QUIZ")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class CustomQuiz extends BaseTimeEntity {
 

--- a/src/main/java/com/_1/spring_rest_api/entity/Question.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Question.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +15,7 @@ import java.util.List;
 @Entity
 @Table(name = "QUESTION")
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Question extends BaseTimeEntity {
@@ -35,9 +36,11 @@ public class Question extends BaseTimeEntity {
     private String back;
 
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<QuizQuestionMapping> quizQuestionMappings = new ArrayList<>();
 
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<UserAnswer> userAnswers = new ArrayList<>();
 
     // DTO로 변환하는 메서드

--- a/src/main/java/com/_1/spring_rest_api/entity/Question.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Question.java
@@ -4,9 +4,9 @@ import com._1.spring_rest_api.api.dto.QuestionResponse;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +14,7 @@ import java.util.List;
 @Entity
 @Table(name = "QUESTION")
 @Getter
-@SuperBuilder
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Question extends BaseTimeEntity {

--- a/src/main/java/com/_1/spring_rest_api/entity/QuizQuestionMapping.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/QuizQuestionMapping.java
@@ -3,14 +3,14 @@ package com._1.spring_rest_api.entity;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "QUIZ_QUESTION_MAPPING")
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class QuizQuestionMapping extends BaseTimeEntity {

--- a/src/main/java/com/_1/spring_rest_api/entity/QuizQuestionMapping.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/QuizQuestionMapping.java
@@ -2,12 +2,16 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "QUIZ_QUESTION_MAPPING")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class QuizQuestionMapping extends BaseTimeEntity {
 

--- a/src/main/java/com/_1/spring_rest_api/entity/QuizSession.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/QuizSession.java
@@ -4,14 +4,14 @@ package com._1.spring_rest_api.entity;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "QUIZ_SESSION")
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class QuizSession extends BaseTimeEntity {

--- a/src/main/java/com/_1/spring_rest_api/entity/QuizSession.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/QuizSession.java
@@ -3,12 +3,16 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "QUIZ_SESSION")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class QuizSession extends BaseTimeEntity {
 

--- a/src/main/java/com/_1/spring_rest_api/entity/QuizWeekMapping.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/QuizWeekMapping.java
@@ -3,14 +3,14 @@ package com._1.spring_rest_api.entity;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "QUIZ_WEEK_MAPPING")
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class QuizWeekMapping extends BaseTimeEntity {

--- a/src/main/java/com/_1/spring_rest_api/entity/QuizWeekMapping.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/QuizWeekMapping.java
@@ -2,12 +2,16 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "QUIZ_WEEK_MAPPING")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class QuizWeekMapping extends BaseTimeEntity {
 

--- a/src/main/java/com/_1/spring_rest_api/entity/SupplementalFile.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/SupplementalFile.java
@@ -3,14 +3,14 @@ package com._1.spring_rest_api.entity;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "SUPPLEMENTAL_FILE")
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class SupplementalFile extends BaseTimeEntity {

--- a/src/main/java/com/_1/spring_rest_api/entity/SupplementalFile.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/SupplementalFile.java
@@ -2,12 +2,16 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "SUPPLEMENTAL_FILE")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class SupplementalFile extends BaseTimeEntity {
 

--- a/src/main/java/com/_1/spring_rest_api/entity/Term.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Term.java
@@ -2,6 +2,8 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +13,8 @@ import java.util.List;
 @Entity
 @Table(name = "TERM")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class Term extends BaseTimeEntity {
 

--- a/src/main/java/com/_1/spring_rest_api/entity/Term.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Term.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +14,7 @@ import java.util.List;
 @Entity
 @Table(name = "TERM")
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class Term extends BaseTimeEntity {
@@ -33,5 +34,6 @@ public class Term extends BaseTimeEntity {
     private Boolean isRequired;
 
     @OneToMany(mappedBy = "term", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<UserAgree> userAgrees = new ArrayList<>();
 }

--- a/src/main/java/com/_1/spring_rest_api/entity/Text.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Text.java
@@ -3,14 +3,14 @@ package com._1.spring_rest_api.entity;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "TEXT")
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class Text extends BaseTimeEntity {

--- a/src/main/java/com/_1/spring_rest_api/entity/Text.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Text.java
@@ -2,12 +2,16 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "TEXT")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class Text extends BaseTimeEntity {
 

--- a/src/main/java/com/_1/spring_rest_api/entity/User.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/User.java
@@ -29,22 +29,40 @@ public class User extends BaseTimeEntity {
     private UserKakao userKakao;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<UserAgree> userAgrees = new ArrayList<>();
 
     @OneToMany(mappedBy = "creator", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<Course> courses = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<QuizSession> quizSessions = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<UserAnswer> userAnswers = new ArrayList<>();
+
+    // 양방향 연관관계 설정 메서드
+    public void linkWithKakao(UserKakao userKakao) {
+        this.userKakao = userKakao;
+        // userKakao의 user 필드가 this가 아닌 경우에만 설정
+        if (userKakao.getUser() != this) {
+            userKakao.linkWithUser(this);
+        }
+    }
+
 
     public User(Long id) {
         this.id = id;
     }
 
-    public void linkWithKakao(UserKakao userKakao) {
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateUserKakao(UserKakao userKakao) {
         this.userKakao = userKakao;
     }
 

--- a/src/main/java/com/_1/spring_rest_api/entity/User.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/User.java
@@ -2,9 +2,7 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +10,8 @@ import java.util.List;
 @Entity
 @Table(name = "UserTB")
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class User extends BaseTimeEntity {
 
@@ -43,5 +42,21 @@ public class User extends BaseTimeEntity {
 
     public User(Long id) {
         this.id = id;
+    }
+
+    public void linkWithKakao(UserKakao userKakao) {
+        this.userKakao = userKakao;
+    }
+
+    public static User createKakaoUser(String email, String name) {
+        if (email == null || email.isEmpty()) {
+            throw new IllegalArgumentException("이메일은 필수 값입니다.");
+        }
+
+        return User.builder()
+                .email(email)
+                .name(name)
+                .isActive(true)
+                .build();
     }
 }

--- a/src/main/java/com/_1/spring_rest_api/entity/UserAgree.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/UserAgree.java
@@ -3,14 +3,14 @@ package com._1.spring_rest_api.entity;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "USER_AGREE")
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserAgree extends BaseTimeEntity {

--- a/src/main/java/com/_1/spring_rest_api/entity/UserAgree.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/UserAgree.java
@@ -2,12 +2,16 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "USER_AGREE")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class UserAgree extends BaseTimeEntity {
 

--- a/src/main/java/com/_1/spring_rest_api/entity/UserAnswer.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/UserAnswer.java
@@ -4,16 +4,16 @@ package com._1.spring_rest_api.entity;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "USER_ANSWER")
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserAnswer extends BaseTimeEntity {

--- a/src/main/java/com/_1/spring_rest_api/entity/UserAnswer.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/UserAnswer.java
@@ -3,6 +3,8 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +13,8 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "USER_ANSWER")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class UserAnswer extends BaseTimeEntity {
 

--- a/src/main/java/com/_1/spring_rest_api/entity/UserKakao.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/UserKakao.java
@@ -3,16 +3,15 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "USER_KAKAO")
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class UserKakao extends BaseTimeEntity {
 
@@ -37,4 +36,31 @@ public class UserKakao extends BaseTimeEntity {
     private LocalDateTime tokenExpiresAt;
 
     // 필요에 따라 추가 정보 (프로필 이미지 URL, 닉네임 등)
+    /**
+     * 카카오 토큰 정보를 업데이트한다.
+     **/
+    public void updateTokens(String accessToken, String refreshToken, LocalDateTime expiresAt) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.tokenExpiresAt = expiresAt;
+    }
+
+    public static UserKakao createKakaoAccountLink(User user, String kakaoId) {
+        if (user == null) {
+            throw new IllegalArgumentException("사용자 정보는 필수입니다.");
+        }
+        if (kakaoId == null || kakaoId.isEmpty()) {
+            throw new IllegalArgumentException("카카오 계정 ID는 필수 값입니다.");
+        }
+
+        UserKakao userKakao = UserKakao.builder()
+                .user(user)
+                .kakaoAccountId(kakaoId)
+                .build();
+
+        // 양방향 연관관계 설정
+        user.linkWithKakao(userKakao);
+
+        return userKakao;
+    }
 }

--- a/src/main/java/com/_1/spring_rest_api/entity/UserKakao.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/UserKakao.java
@@ -3,14 +3,17 @@ package com._1.spring_rest_api.entity;
 
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "USER_KAKAO")
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserKakao extends BaseTimeEntity {
@@ -35,7 +38,15 @@ public class UserKakao extends BaseTimeEntity {
     @Column(name = "token_expires_at")
     private LocalDateTime tokenExpiresAt;
 
-    // 필요에 따라 추가 정보 (프로필 이미지 URL, 닉네임 등)
+    // 양방향 연관관계 설정 메서드
+    public void linkWithUser(User user) {
+        this.user = user;
+        // user의 userKakao 필드가 this가 아닌 경우에만 설정
+        if (user.getUserKakao() != this) {
+            user.linkWithKakao(this);
+        }
+    }
+
     /**
      * 카카오 토큰 정보를 업데이트한다.
      **/
@@ -59,7 +70,7 @@ public class UserKakao extends BaseTimeEntity {
                 .build();
 
         // 양방향 연관관계 설정
-        user.linkWithKakao(userKakao);
+        user.updateUserKakao(userKakao);
 
         return userKakao;
     }

--- a/src/main/java/com/_1/spring_rest_api/entity/Week.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Week.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +15,7 @@ import java.util.List;
 @Entity
 @Table(name = "WEEK")
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Week extends BaseTimeEntity {
@@ -35,15 +36,19 @@ public class Week extends BaseTimeEntity {
     private Integer weekNumber;
 
     @OneToMany(mappedBy = "week", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<Text> texts = new ArrayList<>();
 
     @OneToMany(mappedBy = "week", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<Question> questions = new ArrayList<>();
 
     @OneToMany(mappedBy = "week", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<SupplementalFile> supplementalFiles = new ArrayList<>();
 
     @OneToMany(mappedBy = "week", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<QuizWeekMapping> quizWeekMappings = new ArrayList<>();
 
     public Week(Long id, String title, Course course) {

--- a/src/main/java/com/_1/spring_rest_api/entity/Week.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Week.java
@@ -4,6 +4,7 @@ import com._1.spring_rest_api.api.dto.WeekResponse;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,6 +14,7 @@ import java.util.List;
 @Entity
 @Table(name = "WEEK")
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Week extends BaseTimeEntity {

--- a/src/main/java/com/_1/spring_rest_api/service/UserService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/UserService.java
@@ -4,25 +4,24 @@ import com._1.spring_rest_api.entity.User;
 import com._1.spring_rest_api.entity.UserKakao;
 import com._1.spring_rest_api.repository.UserKakaoRepository;
 import com._1.spring_rest_api.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
     private final UserKakaoRepository userKakaoRepository;
-
-    public UserService(UserRepository userRepository, UserKakaoRepository userKakaoRepository) {
-        this.userRepository = userRepository;
-        this.userKakaoRepository = userKakaoRepository;
-    }
 
     public User findByKakaoId(String kakaoId) {
         Optional<UserKakao> userKakaoOpt = userKakaoRepository.findByKakaoAccountId(kakaoId);
@@ -32,18 +31,13 @@ public class UserService {
     @Transactional
     public User createKakaoUser(String email, String name, String kakaoId) {
         // Create new user
-        User user = new User();
-        user.setEmail(email);
-        user.setName(name);
-        user.setIsActive(true);
+        User user = User.createKakaoUser(email, name);
 
         // Save user to get ID
         User savedUser = userRepository.save(user);
 
         // Create Kakao account link
-        UserKakao userKakao = new UserKakao();
-        userKakao.setUser(savedUser);
-        userKakao.setKakaoAccountId(kakaoId);
+        UserKakao userKakao = UserKakao.createKakaoAccountLink(savedUser, kakaoId);
 
         userKakaoRepository.save(userKakao);
 
@@ -54,22 +48,34 @@ public class UserService {
     public void updateKakaoTokens(User user, String accessToken, String refreshToken, LocalDateTime expiresAt) {
         UserKakao userKakao = user.getUserKakao();
 
-        userKakao.setAccessToken(accessToken);
-        userKakao.setRefreshToken(refreshToken);
-        userKakao.setTokenExpiresAt(expiresAt);
+        userKakao.updateTokens(accessToken, refreshToken, expiresAt);
 
         userKakaoRepository.save(userKakao);
     }
 
     public UserDetails createUserDetails(User user) {
+        return createSecurityPrincipal(user);
+    }
+
+    /**
+     * 사용자 엔티티를 Spring Security 인증 객체로 변환한다.
+     */
+    private UserDetails createSecurityPrincipal(User user) {
         return new org.springframework.security.core.userdetails.User(
                 user.getEmail(),
-                "", // No password for OAuth2 users
+                "", // OAuth2 사용자는 비밀번호 없음
                 user.getIsActive(),
                 true,
                 true,
                 true,
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+                getUserAuthorities()
         );
+    }
+
+    /**
+     * 기본 사용자 권한을 반환한다.
+     */
+    private Collection<? extends GrantedAuthority> getUserAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
     }
 }

--- a/src/test/java/com/_1/spring_rest_api/repository/UserKakaoRepositoryTest.java
+++ b/src/test/java/com/_1/spring_rest_api/repository/UserKakaoRepositoryTest.java
@@ -30,30 +30,29 @@ class UserKakaoRepositoryTest {
     @Autowired
     private UserKakaoRepository userKakaoRepository;
 
-    @Autowired
-    private UserRepository userRepository;
-
     @Test
     void findByKakaoAccountId_shouldReturnUserKakao_whenExists() {
         // Given
         String kakaoAccountId = "kakao_123456789";
 
         // Create a user first
-        User user = new User();
-        user.setEmail("test@example.com");
-        user.setName("Test User");
-        user.setIsActive(true);
+        User user = User.builder()
+                .email("test@example.com")
+                .name("Test User")
+                .isActive(true)
+                .build();
         entityManager.persist(user);
 
         // Create and link UserKakao
-        UserKakao userKakao = new UserKakao();
-        userKakao.setUser(user);
-        userKakao.setKakaoAccountId(kakaoAccountId);
-        userKakao.setAccessToken("test_access_token");
-        userKakao.setRefreshToken("test_refresh_token");
-        userKakao.setTokenExpiresAt(LocalDateTime.now().plusHours(1));
-
+        UserKakao userKakao = UserKakao.builder()
+                .user(user)
+                .kakaoAccountId(kakaoAccountId)
+                .accessToken("test_access_token")
+                .refreshToken("test_refresh_token")
+                .tokenExpiresAt(LocalDateTime.now().plusHours(1))
+                .build();
         entityManager.persist(userKakao);
+
         entityManager.flush();
 
         // When
@@ -64,6 +63,7 @@ class UserKakaoRepositoryTest {
         assertEquals(kakaoAccountId, found.get().getKakaoAccountId());
         assertEquals(user.getId(), found.get().getUser().getId());
         assertEquals("test_access_token", found.get().getAccessToken());
+        assertEquals("test_refresh_token", found.get().getRefreshToken());
     }
 
     @Test
@@ -81,18 +81,20 @@ class UserKakaoRepositoryTest {
     @Test
     void save_shouldPersistUserKakao() {
         // Given
-        User user = new User();
-        user.setEmail("save_test@example.com");
-        user.setName("Save Test User");
-        user.setIsActive(true);
+        User user = User.builder()
+                .email("save_test@example.com")
+                .name("Save Test User")
+                .isActive(true)
+                .build();
         entityManager.persist(user);
 
-        UserKakao userKakao = new UserKakao();
-        userKakao.setUser(user);
-        userKakao.setKakaoAccountId("kakao_save_test_id");
-        userKakao.setAccessToken("save_test_access_token");
-        userKakao.setRefreshToken("save_test_refresh_token");
-        userKakao.setTokenExpiresAt(LocalDateTime.now().plusHours(1));
+        UserKakao userKakao = UserKakao.builder()
+                .user(user)
+                .kakaoAccountId("kakao_save_test_id")
+                .accessToken("save_test_access_token")
+                .refreshToken("save_test_refresh_token")
+                .tokenExpiresAt(LocalDateTime.now().plusHours(1))
+                .build();
 
         // When
         UserKakao saved = userKakaoRepository.save(userKakao);
@@ -109,20 +111,22 @@ class UserKakaoRepositoryTest {
     @Test
     void delete_shouldRemoveUserKakao() {
         // Given
-        User user = new User();
-        user.setEmail("delete_test@example.com");
-        user.setName("Delete Test User");
-        user.setIsActive(true);
+        User user = User.builder()
+                .email("delete_test@example.com")
+                .name("Delete Test User")
+                .isActive(true)
+                .build();
         entityManager.persist(user);
 
-        UserKakao userKakao = new UserKakao();
-        userKakao.setUser(user);
-        userKakao.setKakaoAccountId("kakao_delete_test_id");
-        userKakao.setAccessToken("delete_test_access_token");
-        userKakao.setRefreshToken("delete_test_refresh_token");
-        userKakao.setTokenExpiresAt(LocalDateTime.now().plusHours(1));
-
+        UserKakao userKakao = UserKakao.builder()
+                .user(user)
+                .kakaoAccountId("kakao_delete_test_id")
+                .accessToken("delete_test_access_token")
+                .refreshToken("delete_test_refresh_token")
+                .tokenExpiresAt(LocalDateTime.now().plusHours(1))
+                .build();
         entityManager.persist(userKakao);
+
         entityManager.flush();
 
         // When

--- a/src/test/java/com/_1/spring_rest_api/repository/UserRepositoryTest.java
+++ b/src/test/java/com/_1/spring_rest_api/repository/UserRepositoryTest.java
@@ -34,10 +34,11 @@ class UserRepositoryTest {
         // Given
         String email = "test@example.com";
 
-        User user = new User();
-        user.setEmail(email);
-        user.setName("Test User");
-        user.setIsActive(true);
+        User user = User.builder()
+                .email(email)
+                .name("Test User")
+                .isActive(true)
+                .build();
 
         entityManager.persist(user);
         entityManager.flush();
@@ -66,10 +67,11 @@ class UserRepositoryTest {
     @Test
     void save_shouldPersistUser() {
         // Given
-        User user = new User();
-        user.setEmail("save@example.com");
-        user.setName("Save Test User");
-        user.setIsActive(true);
+        User user = User.builder()
+                .email("save@example.com")
+                .name("Save Test User")
+                .isActive(true)
+                .build();
 
         // When
         User saved = userRepository.save(user);
@@ -86,16 +88,18 @@ class UserRepositoryTest {
     @Test
     void findAll_shouldReturnAllUsers() {
         // Given
-        User user1 = new User();
-        user1.setEmail("user1@example.com");
-        user1.setName("User One");
-        user1.setIsActive(true);
+        User user1 = User.builder()
+                .email("user1@example.com")
+                .name("User One")
+                .isActive(true)
+                .build();
         entityManager.persist(user1);
 
-        User user2 = new User();
-        user2.setEmail("user2@example.com");
-        user2.setName("User Two");
-        user2.setIsActive(true);
+        User user2 = User.builder()
+                .email("user2@example.com")
+                .name("User Two")
+                .isActive(true)
+                .build();
         entityManager.persist(user2);
 
         entityManager.flush();
@@ -113,17 +117,19 @@ class UserRepositoryTest {
     @Test
     void update_shouldModifyUser() {
         // Given
-        User user = new User();
-        user.setEmail("update@example.com");
-        user.setName("Original Name");
-        user.setIsActive(true);
+        User user = User.builder()
+                .email("update@example.com")
+                .name("Original Name")
+                .isActive(true)
+                .build();
 
         entityManager.persist(user);
         entityManager.flush();
 
         // When - update name
         User savedUser = entityManager.find(User.class, user.getId());
-        savedUser.setName("Updated Name");
+        // 도메인 로직을 사용한 방식으로 변경
+        savedUser.updateName("Updated Name");
         userRepository.save(savedUser);
 
         // Then
@@ -135,10 +141,11 @@ class UserRepositoryTest {
     @Test
     void delete_shouldRemoveUser() {
         // Given
-        User user = new User();
-        user.setEmail("delete@example.com");
-        user.setName("Delete Test User");
-        user.setIsActive(true);
+        User user = User.builder()
+                .email("delete@example.com")
+                .name("Delete Test User")
+                .isActive(true)
+                .build();
 
         entityManager.persist(user);
         entityManager.flush();
@@ -154,10 +161,11 @@ class UserRepositoryTest {
     @Test
     void findById_shouldReturnUser_whenExists() {
         // Given
-        User user = new User();
-        user.setEmail("findbyid@example.com");
-        user.setName("Find By ID User");
-        user.setIsActive(true);
+        User user = User.builder()
+                .email("findbyid@example.com")
+                .name("Find By ID User")
+                .isActive(true)
+                .build();
 
         entityManager.persist(user);
         entityManager.flush();

--- a/src/test/java/com/_1/spring_rest_api/security/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/_1/spring_rest_api/security/CustomUserDetailsServiceTest.java
@@ -29,11 +29,12 @@ class CustomUserDetailsServiceTest {
     void loadUserByUsername_shouldReturnUserDetails_whenUserExists() {
         // Given
         String email = "test@example.com";
-        User user = new User();
-        user.setId(1L);
-        user.setEmail(email);
-        user.setName("Test User");
-        user.setIsActive(true);
+        User user = User.builder()
+                .id(1L)
+                .email(email)
+                .name("Test User")
+                .isActive(true)
+                .build();
 
         when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
 
@@ -75,11 +76,12 @@ class CustomUserDetailsServiceTest {
     void loadUserByUsername_shouldReturnDisabledUser_whenUserIsInactive() {
         // Given
         String email = "inactive@example.com";
-        User user = new User();
-        user.setId(1L);
-        user.setEmail(email);
-        user.setName("Inactive User");
-        user.setIsActive(false); // User is inactive
+        User user = User.builder()
+                .id(1L)
+                .email(email)
+                .name("Inactive User")
+                .isActive(false) // User is inactive
+                .build();
 
         when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
 

--- a/src/test/java/com/_1/spring_rest_api/security/OAuth2SuccessHandlerTest.java
+++ b/src/test/java/com/_1/spring_rest_api/security/OAuth2SuccessHandlerTest.java
@@ -92,9 +92,10 @@ class OAuth2SuccessHandlerTest {
 
         when(userService.findByKakaoId(KAKAO_ID)).thenReturn(null);
 
-        User newUser = new User();
-        newUser.setId(1L);
-        newUser.setEmail(EMAIL);
+        User newUser = User.builder()
+                .id(1L)
+                .email(EMAIL)
+                .build();
         when(userService.createKakaoUser(eq(EMAIL), eq(NAME), eq(KAKAO_ID))).thenReturn(newUser);
 
         UserDetails userDetails = mock(UserDetails.class);
@@ -119,7 +120,10 @@ class OAuth2SuccessHandlerTest {
     void onAuthenticationSuccess_shouldIgnore_whenNotKakaoProvider() throws IOException, ServletException {
         // Given
         OAuth2AuthenticationToken mockToken = mock(OAuth2AuthenticationToken.class);
+        OAuth2User mockOAuth2User = mock(OAuth2User.class);  // OAuth2User 모의 객체 생성
+
         when(mockToken.getAuthorizedClientRegistrationId()).thenReturn("google");
+        when(mockToken.getPrincipal()).thenReturn(mockOAuth2User);  // getPrincipal()이 모의 OAuth2User 반환하도록 설정
 
         // When
         oAuth2SuccessHandler.onAuthenticationSuccess(request, response, mockToken);
@@ -132,12 +136,12 @@ class OAuth2SuccessHandlerTest {
 
     // 헬퍼 메서드
     private User mockExistingUser() {
-        User user = new User();
-        user.setId(1L);
-        user.setEmail(EMAIL);
-        user.setName(NAME);
-        user.setIsActive(true);
-        return user;
+        return User.builder()
+                .id(1L)
+                .email(EMAIL)
+                .name(NAME)
+                .isActive(true)
+                .build();
     }
 
     private void mockKakaoAuthentication() {

--- a/src/test/java/com/_1/spring_rest_api/service/UserServiceTest.java
+++ b/src/test/java/com/_1/spring_rest_api/service/UserServiceTest.java
@@ -154,25 +154,27 @@ class UserServiceTest {
 
     // 헬퍼 메서드 - 테스트 사용자 생성
     private User createTestUser() {
-        User user = new User();
-        user.setEmail(TEST_EMAIL);
-        user.setName(TEST_NAME);
-        user.setIsActive(true);
+        User user = User.builder()
+                .email(TEST_EMAIL)
+                .name(TEST_NAME)
+                .isActive(true)
+                .build();
         return userRepository.save(user);
     }
 
     // 헬퍼 메서드 - 테스트 카카오 계정 정보 생성
     private UserKakao createTestUserKakao(User user) {
-        UserKakao userKakao = new UserKakao();
-        userKakao.setUser(user);
-        userKakao.setKakaoAccountId(KAKAO_ID);
-        userKakao.setAccessToken("test_access_token");
-        userKakao.setRefreshToken("test_refresh_token");
-        userKakao.setTokenExpiresAt(LocalDateTime.now().plusHours(1));
+        UserKakao userKakao = UserKakao.builder()
+                .user(user)
+                .kakaoAccountId(KAKAO_ID)
+                .accessToken("test_access_token")
+                .refreshToken("test_refresh_token")
+                .tokenExpiresAt(LocalDateTime.now().plusHours(1))
+                .build();
         UserKakao saved = userKakaoRepository.save(userKakao);
 
-        // User와 UserKakao 연결 (양방향 관계)
-        user.setUserKakao(saved);
+        userKakao.linkWithUser(user);
+
         userRepository.save(user);
 
         return saved;


### PR DESCRIPTION
## 🔍 개요
<!-- 이 PR이 무엇을 위한 것인지 간략하게 설명해주세요 -->
각 엔티티가 Setter 대신 SuperBuilder를 사용하도록 수정.

## 📝 변경사항
<!-- 주요 변경사항을 불릿 포인트로 나열해주세요 -->
- Setter 대신 SuperBuilder 어노테이션 사용
- 관련 코드들 그에 맞게 변경
- 일대다 관계는 @Builder.Default를 설정하여 Warning 제거

Builder 대신 SuperBuilder를 사용한 이유
: 상속하는 BaseEntity값도 설정하려면 Builder 대신 SuperBuilder 사용이 필요함.

## 🧪 테스트 방법
<!-- 이 변경사항을 테스트하는 방법을 설명해주세요 -->

## 📸 스크린샷 (선택사항)
<!-- UI 변경이 있는 경우 스크린샷을 추가해주세요 -->

## 👀 리뷰 요구사항
<!-- 리뷰어에게 특별히 확인을 요청하는 부분이 있다면 작성해주세요 -->
- [ ] 특정 로직 검토 (파일명:라인번호)
- [ ] 성능 개선 확인

## ✅ 체크리스트
- [ ] 코드 스타일 가이드라인을 준수했습니다
- [x] 테스트를 추가/수정했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
close #23 