### PR TITLE
[Fix] Cloud Run 배포 플래그 누락 추가 close #39

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,7 @@ jobs:
             SPRING_PROFILES_ACTIVE=prod
             API_URL=${{ secrets.API_URL }}
           timeout: '300s'
+          flags: '--allow-unauthenticated --cpu=1 --memory=512Mi --min-instances=0 --max-instances=1'
           # vpc-connector: 'projects/${{ secrets.GCP_PROJECT_ID }}/locations/${{ secrets.GCP_REGION }}/connectors/my-vpc-connector'
 
       # 배포 URL 출력


### PR DESCRIPTION

## 🔍 개요
Cloud Run 배포 시 필요한 `--allow-unauthenticated`, 리소스 설정 플래그를 추가했습니다. 이를 통해 설정 누락으로 인한 배포 오류를 방지합니다. issue #39 참고

## 📝 변경사항
- [공식 문서](https://github.com/google-github-actions/deploy-cloudrun) 참고 후 flag 옵션 수정