### PR TITLE
[Feature] API 응답 형식 통일 및 전역 에러 핸들러 구현

### DIFF
--- a/src/main/java/com/_1/spring_rest_api/apipayload/ApiResponse.java
+++ b/src/main/java/com/_1/spring_rest_api/apipayload/ApiResponse.java
@@ -1,0 +1,37 @@
+package com._1.spring_rest_api.apipayload;
+
+import com._1.spring_rest_api.apipayload.code.BaseCode;
+import com._1.spring_rest_api.apipayload.code.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    // 성공한 경우 응답 생성
+
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+            return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/apipayload/code/BaseCode.java
+++ b/src/main/java/com/_1/spring_rest_api/apipayload/code/BaseCode.java
@@ -1,0 +1,8 @@
+package com._1.spring_rest_api.apipayload.code;
+
+public interface BaseCode {
+
+    ReasonDto getReason();
+
+    ReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/com/_1/spring_rest_api/apipayload/code/BaseErrorCode.java
+++ b/src/main/java/com/_1/spring_rest_api/apipayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package com._1.spring_rest_api.apipayload.code;
+
+public interface BaseErrorCode {
+
+    ErrorReasonDto getReason();
+
+    ErrorReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/com/_1/spring_rest_api/apipayload/code/ErrorReasonDto.java
+++ b/src/main/java/com/_1/spring_rest_api/apipayload/code/ErrorReasonDto.java
@@ -1,0 +1,18 @@
+package com._1.spring_rest_api.apipayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDto {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/com/_1/spring_rest_api/apipayload/code/ReasonDto.java
+++ b/src/main/java/com/_1/spring_rest_api/apipayload/code/ReasonDto.java
@@ -1,0 +1,18 @@
+package com._1.spring_rest_api.apipayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDto {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/com/_1/spring_rest_api/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/_1/spring_rest_api/apipayload/code/status/ErrorStatus.java
@@ -1,0 +1,52 @@
+package com._1.spring_rest_api.apipayload.code.status;
+
+import com._1.spring_rest_api.apipayload.code.BaseErrorCode;
+import com._1.spring_rest_api.apipayload.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 사용자 관련 에러
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "사용자를 찾을 수 없습니다."),
+
+    // 코스 관련 에러
+    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "COURSE404", "코스를 찾을 수 없습니다."),
+
+    // 주차 관련 에러
+    WEEK_NOT_FOUND(HttpStatus.NOT_FOUND, "WEEK404", "주차를 찾을 수 없습니다."),
+
+    // 질문 관련 에러
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION404", "질문을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/apipayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/_1/spring_rest_api/apipayload/code/status/SuccessStatus.java
@@ -1,0 +1,40 @@
+package com._1.spring_rest_api.apipayload.code.status;
+
+import com._1.spring_rest_api.apipayload.code.BaseCode;
+import com._1.spring_rest_api.apipayload.code.ReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    // 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+
+}

--- a/src/main/java/com/_1/spring_rest_api/apipayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/_1/spring_rest_api/apipayload/exception/ExceptionAdvice.java
@@ -1,0 +1,105 @@
+package com._1.spring_rest_api.apipayload.exception;
+
+import com._1.spring_rest_api.apipayload.ApiResponse;
+import com._1.spring_rest_api.apipayload.code.ErrorReasonDto;
+import com._1.spring_rest_api.apipayload.code.status.ErrorStatus;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    // FieldErrorDto 내부 클래스 정의
+    @Getter
+    @AllArgsConstructor
+    public static class FieldErrorDto {
+        private String field;
+        private String message;
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ApiResponse<Object>> handleEntityNotFoundException(EntityNotFoundException e) {
+        log.warn("Entity not found: {}", e.getMessage());
+
+        // 메시지에서 엔티티 유형을 추출하여 적절한 에러 상태 결정
+        ErrorStatus errorStatus = getErrorStatusFromMessage(e.getMessage());
+
+        ApiResponse<Object> apiResponse = ApiResponse.onFailure(
+                errorStatus.getCode(),
+                e.getMessage(),
+                null);
+        return ResponseEntity.status(errorStatus.getHttpStatus()).body(apiResponse);
+    }
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Object>> handleGeneralException(GeneralException e) {
+        log.error("General exception occurred: {}", e.getMessage());
+        ErrorReasonDto errorReasonDto = e.getErrorReasonHttpStatus();
+        ApiResponse<Object> apiResponse = ApiResponse.onFailure(
+                errorReasonDto.getCode(),
+                errorReasonDto.getMessage(),
+                null
+        );
+        return ResponseEntity.status(errorReasonDto.getHttpStatus()).body(apiResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<List<FieldErrorDto>>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.warn("Method argument validation failed: {}", e.getMessage());
+
+        List<FieldErrorDto> fieldErrors = new ArrayList<>();
+        BindingResult bindingResult = e.getBindingResult();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            fieldErrors.add(new FieldErrorDto(
+                    fieldError.getField(),
+                    fieldError.getDefaultMessage()
+            ));
+        }
+
+        ApiResponse<List<FieldErrorDto>> apiResponse = ApiResponse.onFailure(
+                ErrorStatus._BAD_REQUEST.getCode(),
+                ErrorStatus._BAD_REQUEST.getMessage(),
+                fieldErrors);
+
+        return ResponseEntity.status(ErrorStatus._BAD_REQUEST.getHttpStatus()).body(apiResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleException(Exception e) {
+        log.error("Unhandled exception occurred", e);  // 스택 트레이스 포함 로깅
+        ApiResponse<Object> apiResponse = ApiResponse.onFailure(
+                ErrorStatus._INTERNAL_SERVER_ERROR.getCode(),
+                ErrorStatus._INTERNAL_SERVER_ERROR.getMessage(),
+                null);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(apiResponse);
+    }
+
+    // 에러 메시지에서 적절한 ErrorStatus를 결정하는 헬퍼 메서드
+    private ErrorStatus getErrorStatusFromMessage(String message) {
+        if (message.contains("User not found")) {
+            return ErrorStatus.USER_NOT_FOUND;
+        } else if (message.contains("Course not found")) {
+            return ErrorStatus.COURSE_NOT_FOUND;
+        } else if (message.contains("Week not found")) {
+            return ErrorStatus.WEEK_NOT_FOUND;
+        } else if (message.contains("Question not found")) {
+            return ErrorStatus.QUESTION_NOT_FOUND;
+        } else {
+            return ErrorStatus._BAD_REQUEST; // 기본 에러 상태
+        }
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/apipayload/exception/GeneralException.java
+++ b/src/main/java/com/_1/spring_rest_api/apipayload/exception/GeneralException.java
@@ -1,0 +1,20 @@
+package com._1.spring_rest_api.apipayload.exception;
+
+import com._1.spring_rest_api.apipayload.code.BaseErrorCode;
+import com._1.spring_rest_api.apipayload.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+    private final BaseErrorCode code;
+
+    public ErrorReasonDto getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDto getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
<!-- 이 PR이 무엇을 위한 것인지 간략하게 설명해주세요 -->
API 응답 형식을 통일시켰고, 전역 에러 핸들러를 구현했습니다.

## 📝 변경사항
<!-- 주요 변경사항을 불릿 포인트로 나열해주세요 -->
- 

## 👀 리뷰 요구사항
기존 컨트롤러 코드들 응답 형식 맞추고 커스텀 에러들도 던지면 좋을거 같습니다.

성공 응답은 SuccessStatus enum에서 추가하고, 실패 응답은 ErrorStatus에서 추가합니다.

close #38 