### PR TITLE
[Feat] 주차별 퀴즈 생성, 조회, 삭제 API 구현

### DIFF
--- a/src/main/java/com/_1/spring_rest_api/api/controller/CustomQuizController.java
+++ b/src/main/java/com/_1/spring_rest_api/api/controller/CustomQuizController.java
@@ -1,0 +1,40 @@
+package com._1.spring_rest_api.api.controller;
+
+import com._1.spring_rest_api.api.dto.CreateQuizRequest;
+import com._1.spring_rest_api.api.dto.CreateQuizResponse;
+import com._1.spring_rest_api.service.QuizCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/quizzes")
+@RequiredArgsConstructor
+@Tag(name = "Quiz API", description = "퀴즈 생성 및 조회 API")
+public class CustomQuizController {
+
+    private final QuizCommandService quizCommandService;
+
+    @PostMapping
+    @Operation(summary = "퀴즈 생성", description = "사용자가 선택한 주차들로 새로운 퀴즈를 생성합니다")
+    public ResponseEntity<CreateQuizResponse> createQuiz(@Valid @RequestBody CreateQuizRequest request) {
+        Long quizId = quizCommandService.createQuiz(request);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(quizId)
+                .toUri();
+
+        return ResponseEntity.created(location).body(new CreateQuizResponse(quizId));
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/api/controller/CustomQuizController.java
+++ b/src/main/java/com/_1/spring_rest_api/api/controller/CustomQuizController.java
@@ -56,4 +56,12 @@ public class CustomQuizController {
         QuizDetailResponse quiz = quizQueryService.getQuizDetail(quizId);
         return ResponseEntity.ok(quiz);
     }
+
+    @DeleteMapping("/{quizId}")
+    @Operation(summary = "퀴즈 삭제", description = "퀴즈 ID로 특정 퀴즈를 삭제합니다")
+    public ResponseEntity<Void> deleteQuiz(
+            @Parameter(description = "퀴즈 ID") @PathVariable Long quizId) {
+        quizCommandService.deleteQuiz(quizId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/_1/spring_rest_api/api/controller/CustomQuizController.java
+++ b/src/main/java/com/_1/spring_rest_api/api/controller/CustomQuizController.java
@@ -2,19 +2,21 @@ package com._1.spring_rest_api.api.controller;
 
 import com._1.spring_rest_api.api.dto.CreateQuizRequest;
 import com._1.spring_rest_api.api.dto.CreateQuizResponse;
+import com._1.spring_rest_api.api.dto.QuizDetailResponse;
+import com._1.spring_rest_api.api.dto.QuizSummaryResponse;
 import com._1.spring_rest_api.service.QuizCommandService;
+import com._1.spring_rest_api.service.QuizQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/quizzes")
@@ -23,6 +25,7 @@ import java.net.URI;
 public class CustomQuizController {
 
     private final QuizCommandService quizCommandService;
+    private final QuizQueryService quizQueryService;
 
     @PostMapping
     @Operation(summary = "퀴즈 생성", description = "사용자가 선택한 주차들로 새로운 퀴즈를 생성합니다")
@@ -36,5 +39,21 @@ public class CustomQuizController {
                 .toUri();
 
         return ResponseEntity.created(location).body(new CreateQuizResponse(quizId));
+    }
+
+    @GetMapping
+    @Operation(summary = "사용자별 전체 퀴즈 목록 조회", description = "특정 사용자가 생성한 모든 퀴즈 목록을 조회합니다")
+    public ResponseEntity<List<QuizSummaryResponse>> getUserQuizzes(
+            @Parameter(description = "사용자 ID") @RequestParam Long userId) {
+        List<QuizSummaryResponse> quizzes = quizQueryService.getQuizzesByUserId(userId);
+        return ResponseEntity.ok(quizzes);
+    }
+
+    @GetMapping("/{quizId}")
+    @Operation(summary = "퀴즈 상세 조회", description = "퀴즈 ID로 퀴즈의 상세 정보와 포함된 질문들을 조회합니다")
+    public ResponseEntity<QuizDetailResponse> getQuizDetail(
+            @Parameter(description = "퀴즈 ID") @PathVariable Long quizId) {
+        QuizDetailResponse quiz = quizQueryService.getQuizDetail(quizId);
+        return ResponseEntity.ok(quiz);
     }
 }

--- a/src/main/java/com/_1/spring_rest_api/api/dto/CreateQuizRequest.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/CreateQuizRequest.java
@@ -1,0 +1,34 @@
+package com._1.spring_rest_api.api.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateQuizRequest {
+
+    @NotNull(message = "사용자 ID는 필수입니다")
+    private Long userId;
+
+    @NotEmpty(message = "퀴즈 제목은 필수입니다")
+    @Size(min = 1, max = 100, message = "퀴즈 제목은 1-100자 사이여야 합니다")
+    private String title;
+
+    private String description;
+
+    @NotEmpty(message = "최소 하나 이상의 주차를 선택해야 합니다")
+    private List<Long> weekIds;
+
+    private String quizType; // 예: "WEEKLY", "CUSTOM"
+
+    private Integer questionCount; // 랜덤으로 선택할 질문 수 (옵션)
+}

--- a/src/main/java/com/_1/spring_rest_api/api/dto/CreateQuizResponse.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/CreateQuizResponse.java
@@ -1,0 +1,10 @@
+package com._1.spring_rest_api.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateQuizResponse {
+    private Long id;
+}

--- a/src/main/java/com/_1/spring_rest_api/api/dto/QuizDetailResponse.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/QuizDetailResponse.java
@@ -1,0 +1,26 @@
+package com._1.spring_rest_api.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizDetailResponse {
+    private Long id;
+    private String title;
+    private String description;
+    private String quizType;
+    private Integer totalQuestions;
+    private UserSummaryResponse creator;
+    private List<WeekSummaryResponse> weeks;
+    private List<QuestionResponse> questions;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/_1/spring_rest_api/api/dto/QuizSummaryResponse.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/QuizSummaryResponse.java
@@ -1,0 +1,22 @@
+package com._1.spring_rest_api.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizSummaryResponse {
+    private Long id;
+    private String title;
+    private String description;
+    private String quizType;
+    private Integer totalQuestions;
+    private Integer weekCount;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/_1/spring_rest_api/api/dto/UserSummaryResponse.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/UserSummaryResponse.java
@@ -1,0 +1,16 @@
+package com._1.spring_rest_api.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSummaryResponse {
+    private Long id;
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/_1/spring_rest_api/api/dto/WeekSummaryResponse.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/WeekSummaryResponse.java
@@ -1,0 +1,18 @@
+package com._1.spring_rest_api.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeekSummaryResponse {
+    private Long id;
+    private String title;
+    private Integer weekNumber;
+    private Long courseId;
+    private String courseTitle;
+}

--- a/src/main/java/com/_1/spring_rest_api/entity/CustomQuiz.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/CustomQuiz.java
@@ -52,6 +52,53 @@ public class CustomQuiz extends BaseTimeEntity {
     @Builder.Default
     private List<QuizWeekMapping> quizWeekMappings = new ArrayList<>();
 
+    // 총 질문 수 업데이트 메서드
+    public void updateTotalQuestions(int count) {
+        this.totalQuestions = count;
+    }
+
+    public static CustomQuiz create(User user, String title, String description, String quizType) {
+        if (user == null) {
+            throw new IllegalArgumentException("생성자(사용자)는 null이 될 수 없습니다");
+        }
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("퀴즈 제목은 빈 값이 될 수 없습니다");
+        }
+
+        return CustomQuiz.builder()
+                .creator(user)
+                .title(title)
+                .description(description)
+                .quizType(quizType)
+                .totalQuestions(0)
+                .build();
+    }
+
+    /**
+     * 질문을 퀴즈에 추가
+     */
+    public void addQuestion(Question question) {
+        if (question == null) {
+            throw new IllegalArgumentException("질문은 null이 될 수 없습니다.");
+        }
+
+        // 이미 추가된 질문인지 확인
+        boolean alreadyAdded = this.quizQuestionMappings.stream()
+                .anyMatch(mapping -> mapping.getQuestion().getId().equals(question.getId()));
+
+        if (alreadyAdded) {
+            return; // 이미 추가된 질문이면 무시
+        }
+
+        // 정적 팩토리 메서드를 통해 매핑 생성 및 양방향 연관관계 설정
+        QuizQuestionMapping mapping = QuizQuestionMapping.create(this, question);
+
+        // 질문 수 증가
+        this.updateTotalQuestions(this.totalQuestions + 1);
+    }
+
+
+
     // CustomQuiz와 QuizSession 간의 양방향 연관관계 메서드
     public void addQuizSession(QuizSession session) {
         this.quizSessions.add(session);

--- a/src/main/java/com/_1/spring_rest_api/entity/QuizQuestionMapping.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/QuizQuestionMapping.java
@@ -28,6 +28,18 @@ public class QuizQuestionMapping extends BaseTimeEntity {
     @JoinColumn(name = "question_id")
     private Question question;
 
+    public static QuizQuestionMapping create(CustomQuiz quiz, Question question) {
+        // 새 인스턴스 생성
+        QuizQuestionMapping mapping = QuizQuestionMapping.builder()
+                .build();
+
+        // 양방향 연관관계 설정
+        mapping.changeQuiz(quiz);
+        mapping.changeQuestion(question);
+
+        return mapping;
+    }
+
     // CustomQuiz와 QuizQuestionMapping 간의 양방향 연관관계 메서드
     public void changeQuiz(CustomQuiz quiz) {
         this.quiz = quiz;

--- a/src/main/java/com/_1/spring_rest_api/repository/CustomQuizRepository.java
+++ b/src/main/java/com/_1/spring_rest_api/repository/CustomQuizRepository.java
@@ -2,7 +2,15 @@ package com._1.spring_rest_api.repository;
 
 import com._1.spring_rest_api.entity.CustomQuiz;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 
 public interface CustomQuizRepository extends JpaRepository<CustomQuiz, Long> {
+
+    @Query("SELECT q FROM CustomQuiz q WHERE q.creator.id = :creatorId ORDER BY q.createAt DESC")
+    List<CustomQuiz> findAllByCreatorId(@Param("creatorId") Long creatorId);
+
 }

--- a/src/main/java/com/_1/spring_rest_api/repository/CustomQuizRepository.java
+++ b/src/main/java/com/_1/spring_rest_api/repository/CustomQuizRepository.java
@@ -1,0 +1,8 @@
+package com._1.spring_rest_api.repository;
+
+import com._1.spring_rest_api.entity.CustomQuiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface CustomQuizRepository extends JpaRepository<CustomQuiz, Long> {
+}

--- a/src/main/java/com/_1/spring_rest_api/repository/QuizQuestionMappingRepository.java
+++ b/src/main/java/com/_1/spring_rest_api/repository/QuizQuestionMappingRepository.java
@@ -1,0 +1,7 @@
+package com._1.spring_rest_api.repository;
+
+import com._1.spring_rest_api.entity.QuizQuestionMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizQuestionMappingRepository extends JpaRepository<QuizQuestionMapping, Long> {
+}

--- a/src/main/java/com/_1/spring_rest_api/repository/QuizSessionRepository.java
+++ b/src/main/java/com/_1/spring_rest_api/repository/QuizSessionRepository.java
@@ -1,0 +1,7 @@
+package com._1.spring_rest_api.repository;
+
+import com._1.spring_rest_api.entity.QuizSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> {
+}

--- a/src/main/java/com/_1/spring_rest_api/repository/QuizWeekMappingRepository.java
+++ b/src/main/java/com/_1/spring_rest_api/repository/QuizWeekMappingRepository.java
@@ -1,0 +1,7 @@
+package com._1.spring_rest_api.repository;
+
+import com._1.spring_rest_api.entity.QuizWeekMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizWeekMappingRepository extends JpaRepository <QuizWeekMapping, Long> {
+}

--- a/src/main/java/com/_1/spring_rest_api/service/QuizCommandService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizCommandService.java
@@ -1,0 +1,8 @@
+package com._1.spring_rest_api.service;
+
+import com._1.spring_rest_api.api.dto.CreateQuizRequest;
+
+public interface QuizCommandService {
+
+    Long createQuiz(CreateQuizRequest request);
+}

--- a/src/main/java/com/_1/spring_rest_api/service/QuizCommandService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizCommandService.java
@@ -5,4 +5,6 @@ import com._1.spring_rest_api.api.dto.CreateQuizRequest;
 public interface QuizCommandService {
 
     Long createQuiz(CreateQuizRequest request);
+
+    void deleteQuiz(Long quizId);
 }

--- a/src/main/java/com/_1/spring_rest_api/service/QuizCommandServiceImpl.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizCommandServiceImpl.java
@@ -1,0 +1,115 @@
+package com._1.spring_rest_api.service;
+
+import com._1.spring_rest_api.api.dto.CreateQuizRequest;
+import com._1.spring_rest_api.entity.*;
+import com._1.spring_rest_api.repository.*;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class QuizCommandServiceImpl implements QuizCommandService{
+
+    private final QuestionRepository questionRepository;
+    private final WeekRepository weekRepository;
+    private final UserRepository userRepository;
+    private final CustomQuizRepository customQuizRepository;
+    private final QuizQuestionMappingRepository quizQuestionMappingRepository;
+    private final QuizWeekMappingRepository quizWeekMappingRepository;
+    private final QuizSessionRepository quizSessionRepository;
+
+    /**
+     * 사용자 ID, 주차 ID 리스트, 그리고 질문 ID 리스트(선택)를 기반으로 새 퀴즈를 생성합니다.
+     */
+    public Long createQuiz(CreateQuizRequest request) {
+        // 사용자 찾기
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + request.getUserId()));
+
+        // 새 퀴즈 엔티티 생성
+        CustomQuiz quiz = CustomQuiz.create(user, request.getTitle(), request.getDescription(), request.getQuizType());
+
+        // 퀴즈 저장 (ID 발급)
+        CustomQuiz savedQuiz = customQuizRepository.save(quiz);
+
+        // 주차 연결
+        connectWeeksToQuiz(request.getWeekIds(), savedQuiz);
+
+        // 질문 처리
+        processQuestions(request, savedQuiz);
+
+        return savedQuiz.getId();
+    }
+
+    // 주차와 퀴즈 연결
+    private void connectWeeksToQuiz(List<Long> weekIds, CustomQuiz quiz) {
+        if (weekIds == null || weekIds.isEmpty()) {
+            return;
+        }
+
+        for (Long weekId : weekIds) {
+            Week week = weekRepository.findById(weekId)
+                    .orElseThrow(() -> new EntityNotFoundException("Week not found with id: " + weekId));
+
+            // 주차와 퀴즈 연결 저장 (도메인 로직 활용)
+            QuizWeekMapping mapping = QuizWeekMapping.builder()
+                    .quiz(quiz)
+                    .week(week)
+                    .build();
+
+            // 양방향 연관관계 설정
+            mapping.changeQuiz(quiz);
+            mapping.changeWeek(week);
+
+            quizWeekMappingRepository.save(mapping);
+        }
+    }
+
+    // 질문 처리 로직
+    private void processQuestions(CreateQuizRequest request, CustomQuiz quiz) {
+        Set<Question> questions = new HashSet<>();
+
+        // 주차 기반 질문 선택
+        if (request.getWeekIds() != null && !request.getWeekIds().isEmpty()) {
+            // 선택된 모든 주차의 질문 가져오기
+            List<Question> weekQuestions = getQuestionList(request);
+
+            // 질문 수 제한이 있는 경우 랜덤 선택
+            weekQuestions = getRandomQuestionsIfHasLimit(request, weekQuestions);
+
+            questions.addAll(weekQuestions);
+        }
+
+        // 질문 중복 제거 및 퀴즈에 추가
+        for (Question question : questions) {
+            quiz.addQuestion(question);
+        }
+
+        // 총 질문 수 업데이트 및 저장
+        quiz.updateTotalQuestions(questions.size());
+        customQuizRepository.save(quiz);
+    }
+
+    private static List<Question> getRandomQuestionsIfHasLimit(CreateQuizRequest request, List<Question> weekQuestions) {
+        if (request.getQuestionCount() != null && request.getQuestionCount() > 0 &&
+                request.getQuestionCount() < weekQuestions.size()) {
+            // 무작위 선택
+            Collections.shuffle(weekQuestions);
+            weekQuestions = weekQuestions.subList(0, request.getQuestionCount());
+        }
+        return weekQuestions;
+    }
+
+    private List<Question> getQuestionList(CreateQuizRequest request) {
+        List<Question> weekQuestions = new ArrayList<>();
+        for (Long weekId : request.getWeekIds()) {
+            weekQuestions.addAll(questionRepository.findAllByWeekId(weekId));
+        }
+        return weekQuestions;
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/service/QuizCommandServiceImpl.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizCommandServiceImpl.java
@@ -26,6 +26,7 @@ public class QuizCommandServiceImpl implements QuizCommandService{
     /**
      * 사용자 ID, 주차 ID 리스트, 그리고 질문 ID 리스트(선택)를 기반으로 새 퀴즈를 생성합니다.
      */
+    @Override
     public Long createQuiz(CreateQuizRequest request) {
         // 사용자 찾기
         User user = userRepository.findById(request.getUserId())
@@ -44,6 +45,14 @@ public class QuizCommandServiceImpl implements QuizCommandService{
         processQuestions(request, savedQuiz);
 
         return savedQuiz.getId();
+    }
+
+    @Override
+    public void deleteQuiz(Long quizId) {
+        if (!customQuizRepository.existsById(quizId)) {
+            throw new EntityNotFoundException("Quiz not found with id: " + quizId);
+        }
+        customQuizRepository.deleteById(quizId);
     }
 
     // 주차와 퀴즈 연결

--- a/src/main/java/com/_1/spring_rest_api/service/QuizQueryService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizQueryService.java
@@ -1,0 +1,4 @@
+package com._1.spring_rest_api.service;
+
+public interface QuizQueryService {
+}

--- a/src/main/java/com/_1/spring_rest_api/service/QuizQueryService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizQueryService.java
@@ -1,4 +1,13 @@
 package com._1.spring_rest_api.service;
 
+import com._1.spring_rest_api.api.dto.QuizDetailResponse;
+import com._1.spring_rest_api.api.dto.QuizSummaryResponse;
+
+import java.util.List;
+
 public interface QuizQueryService {
+
+    List<QuizSummaryResponse> getQuizzesByUserId(Long userId);
+
+    QuizDetailResponse getQuizDetail(Long quizId);
 }

--- a/src/main/java/com/_1/spring_rest_api/service/QuizQueryServiceImpl.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizQueryServiceImpl.java
@@ -1,0 +1,4 @@
+package com._1.spring_rest_api.service;
+
+public class QuizQueryServiceImpl {
+}

--- a/src/main/java/com/_1/spring_rest_api/service/QuizQueryServiceImpl.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizQueryServiceImpl.java
@@ -1,4 +1,99 @@
 package com._1.spring_rest_api.service;
 
-public class QuizQueryServiceImpl {
+import com._1.spring_rest_api.api.dto.*;
+import com._1.spring_rest_api.entity.*;
+import com._1.spring_rest_api.repository.CustomQuizRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QuizQueryServiceImpl implements QuizQueryService{
+
+    private final CustomQuizRepository customQuizRepository;
+
+    @Override
+    public List<QuizSummaryResponse> getQuizzesByUserId(Long userId) {
+        List<CustomQuiz> quizzes = customQuizRepository.findAllByCreatorId(userId);
+
+        return quizzes.stream()
+                .map(this::convertToSummaryResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public QuizDetailResponse getQuizDetail(Long quizId) {
+        CustomQuiz quiz = customQuizRepository.findById(quizId)
+                .orElseThrow(() -> new EntityNotFoundException("Quiz not found with id: " + quizId));
+
+        return convertToDetailResponse(quiz);
+    }
+
+    // CustomQuiz 엔티티를 QuizSummaryResponse DTO로 변환
+    private QuizSummaryResponse convertToSummaryResponse(CustomQuiz quiz) {
+        int weekCount = quiz.getQuizWeekMappings().size();
+
+        return QuizSummaryResponse.builder()
+                .id(quiz.getId())
+                .title(quiz.getTitle())
+                .description(quiz.getDescription())
+                .quizType(quiz.getQuizType())
+                .totalQuestions(quiz.getTotalQuestions())
+                .weekCount(weekCount)
+                .createdAt(quiz.getCreateAt())
+                .build();
+    }
+
+    // CustomQuiz 엔티티를 QuizDetailResponse DTO로 변환
+    private QuizDetailResponse convertToDetailResponse(CustomQuiz quiz) {
+        // 1. 연관된 주차 정보 변환
+        List<WeekSummaryResponse> weeks = quiz.getQuizWeekMappings().stream()
+                .map(QuizWeekMapping::getWeek)
+                .map(this::convertToWeekSummaryResponse)
+                .collect(Collectors.toList());
+
+        // 2. 포함된 질문 정보 변환
+        List<QuestionResponse> questions = quiz.getQuizQuestionMappings().stream()
+                .map(QuizQuestionMapping::getQuestion)
+                .map(Question::toQuestionResponse)
+                .collect(Collectors.toList());
+
+        // 3. 생성자 정보 변환
+        UserSummaryResponse creator = UserSummaryResponse.builder()
+                .id(quiz.getCreator().getId())
+                .name(quiz.getCreator().getName())
+                .email(quiz.getCreator().getEmail())
+                .build();
+
+        // 4. 최종 응답 DTO 생성
+        return QuizDetailResponse.builder()
+                .id(quiz.getId())
+                .title(quiz.getTitle())
+                .description(quiz.getDescription())
+                .quizType(quiz.getQuizType())
+                .totalQuestions(quiz.getTotalQuestions())
+                .creator(creator)
+                .weeks(weeks)
+                .questions(questions)
+                .createdAt(quiz.getCreateAt())
+                .modifiedAt(quiz.getModifiedAt())
+                .build();
+    }
+
+    // Week 엔티티를 WeekSummaryResponse DTO로 변환
+    private WeekSummaryResponse convertToWeekSummaryResponse(Week week) {
+        return WeekSummaryResponse.builder()
+                .id(week.getId())
+                .title(week.getTitle())
+                .weekNumber(week.getWeekNumber())
+                .courseId(week.getCourse().getId())
+                .courseTitle(week.getCourse().getTitle())
+                .build();
+    }
 }


### PR DESCRIPTION
## 🔍 개요
<!-- 이 PR이 무엇을 위한 것인지 간략하게 설명해주세요 -->
여러 주차 혹은 단일 주차의 텍스트를 골라 퀴즈를 생성하는 API를 구현했습니다.
사용자가 만든 전체 퀴즈를 조회하는 API와 단일 퀴즈를 조회하는 API도 구현했습니다.
단일 퀴즈를 삭제하는 API도 구현했습니다.

## 📝 변경사항
<!-- 주요 변경사항을 불릿 포인트로 나열해주세요 -->
- 주차별 퀴즈 생성 API 구현
- 사용자별 전체 퀴즈 목록 조회 API 구현
- 퀴즈 ID로 퀴즈 상세 조회 API 구현
- 퀴즈 ID로 퀴즈 삭제 API 구현

close #35 

## 📸 스크린샷 (선택사항)
<!-- UI 변경이 있는 경우 스크린샷을 추가해주세요 -->
![image](https://github.com/user-attachments/assets/e1ab4fbd-16e9-48cd-96b8-4d7d21cae279)
