### PR TITLE
[Feat] 강의 내용에 대한 키워드 생성 및 조회 API 구현

### DIFF
--- a/src/main/java/com/_1/spring_rest_api/api/controller/TextController.java
+++ b/src/main/java/com/_1/spring_rest_api/api/controller/TextController.java
@@ -126,4 +126,18 @@ public class TextController {
         String summation = claudeService.generateSummation(textId);
         return ResponseEntity.ok(summation);
     }
+
+    @PostMapping("/keywords/{textId}")
+    @Operation(
+            summary = "키워드 데이터 생성",
+            description = "강의 데이터를 분석하여 핵심 키워드 7개를 자동으로 추출합니다. " +
+                    "이 기능은 강의 내용의 중요 개념을 빠르게 파악할 수 있도록 도와줍니다. " +
+                    "해당 강의에 이미 키워드가 존재하는 경우, 기존 키워드는 삭제되고 새로 생성된 키워드로 완전히 대체됩니다."
+    )
+    public ResponseEntity<?> createKeywordsById(
+            @PathVariable Long textId
+    ) {
+        List<String> keywords = claudeService.generateKeywords(textId);
+        return ResponseEntity.ok(keywords);
+    }
 }

--- a/src/main/java/com/_1/spring_rest_api/api/controller/TextController.java
+++ b/src/main/java/com/_1/spring_rest_api/api/controller/TextController.java
@@ -140,4 +140,16 @@ public class TextController {
         List<String> keywords = claudeService.generateKeywords(textId);
         return ResponseEntity.ok(keywords);
     }
+
+    @GetMapping("/keywords/{textId}")
+    @Operation(
+            summary = "키워드를 조회합니다.",
+            description = "textId로 생성된 키워드 7개를 조회합니다."
+    )
+    public ResponseEntity<List<String>> getKeywordsById(
+            @PathVariable Long textId
+    ) {
+        List<String> keywords = claudeService.getKeywords(textId);
+        return ResponseEntity.ok(keywords);
+    }
 }

--- a/src/main/java/com/_1/spring_rest_api/entity/Keyword.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Keyword.java
@@ -1,0 +1,27 @@
+package com._1.spring_rest_api.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "Keyword")
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Keyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "TEXT_id")
+    private Text text;
+}

--- a/src/main/java/com/_1/spring_rest_api/repository/KeywordRepository.java
+++ b/src/main/java/com/_1/spring_rest_api/repository/KeywordRepository.java
@@ -1,0 +1,11 @@
+package com._1.spring_rest_api.repository;
+
+import com._1.spring_rest_api.entity.Keyword;
+import com._1.spring_rest_api.entity.Text;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+    List<Keyword> findAllByText(Text text);
+}

--- a/src/main/java/com/_1/spring_rest_api/service/ClaudeService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/ClaudeService.java
@@ -94,6 +94,14 @@ public class ClaudeService {
         return generateKeywordsByClaude(textId, content);
     }
 
+    @Transactional(readOnly = true)
+    public List<String> getKeywords(Long textId) {
+        Text text = textRepository.findById(textId).orElseThrow(
+                () -> new EntityNotFoundException("Text not found with id: " + textId));
+        List<Keyword> existingKeywords = keywordRepository.findAllByText(text);
+        return existingKeywords.stream().map(Keyword::getContent).collect(Collectors.toList());
+    }
+
     private List<String> generateKeywordsByClaude(Long textId, String content) {
         String cleanText = content
                 .replace("\\n", "\n")


### PR DESCRIPTION
## 🔍 개요
#48 

강의 내용에 대한 키워드 생성 및 조회 API를 구현했습니다.
각 강의 콘텐츠별로 7개의 핵심 키워드가 자동 생성되며, 키워드 재생성 요청 시 기존 키워드는 삭제되고 새로운 키워드로 대체됩니다. 키워드 관리를 위해 독립적인 Keyword 엔티티를 설계하여 구현했습니다.

<img width="563" alt="스크린샷 2025-05-17 오후 5 33 59" src="https://github.com/user-attachments/assets/67b63155-e0cf-4557-b75d-65a79f7b3b78" />
