### PR TITLE
[Feature] 유저 퀴즈 세션 관리 API 구현

### DIFF
--- a/src/main/java/com/_1/spring_rest_api/api/controller/CustomQuizController.java
+++ b/src/main/java/com/_1/spring_rest_api/api/controller/CustomQuizController.java
@@ -64,4 +64,13 @@ public class CustomQuizController {
         quizCommandService.deleteQuiz(quizId);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{quizId}/start")
+    @Operation(summary = "퀴즈 세션 시작", description = "사용자가 특정 퀴즈를 시작하여 퀴즈 세션을 생성합니다")
+    public ResponseEntity<Long> startQuizSession(
+            @Parameter(description = "퀴즈 ID") @PathVariable Long quizId,
+            @Parameter(description = "사용자 ID") @RequestParam Long userId) {
+        Long sessionId = quizCommandService.startQuizSession(quizId, userId);
+        return ResponseEntity.ok(sessionId);
+    }
 }

--- a/src/main/java/com/_1/spring_rest_api/api/controller/QuizSessionController.java
+++ b/src/main/java/com/_1/spring_rest_api/api/controller/QuizSessionController.java
@@ -1,0 +1,66 @@
+package com._1.spring_rest_api.api.controller;
+
+import com._1.spring_rest_api.api.dto.*;
+import com._1.spring_rest_api.service.QuizSessionCommandService;
+import com._1.spring_rest_api.service.QuizSessionQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/quiz-sessions")
+@RequiredArgsConstructor
+@Tag(name = "Quiz Session API", description = "퀴즈 세션 관리 API")
+public class QuizSessionController {
+
+    private final QuizSessionCommandService quizSessionCommandService;
+    private final QuizSessionQueryService quizSessionQueryService;
+
+    @GetMapping("/user/{userId}")
+    @Operation(summary = "사용자별 퀴즈 세션 목록 조회", description = "특정 사용자의 모든 퀴즈 세션 목록을 조회합니다")
+    public ResponseEntity<List<QuizSessionResponse>> getUserQuizSessions(
+            @Parameter(description = "사용자 ID") @PathVariable Long userId) {
+        List<QuizSessionResponse> sessions = quizSessionQueryService.getUserQuizSessions(userId);
+        return ResponseEntity.ok(sessions);
+    }
+
+    @GetMapping("/{sessionId}")
+    @Operation(summary = "퀴즈 세션 상세 조회", description = "퀴즈 세션의 상세 정보를 조회합니다")
+    public ResponseEntity<QuizSessionDetailResponse> getSessionDetail(
+            @Parameter(description = "세션 ID") @PathVariable Long sessionId) {
+        QuizSessionDetailResponse session = quizSessionQueryService.getSessionDetail(sessionId);
+        return ResponseEntity.ok(session);
+    }
+
+    @PostMapping("/{sessionId}/answer")
+    @Operation(summary = "질문 답변", description = "현재 질문에 대한 답변을 제출하고 결과를 반환합니다")
+    public ResponseEntity<AnswerResponse> answerQuestion(
+            @Parameter(description = "세션 ID") @PathVariable Long sessionId,
+            @Valid @RequestBody AnswerRequest request) {
+        AnswerResponse response = quizSessionCommandService.answerQuestion(sessionId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{sessionId}/complete")
+    @Operation(summary = "퀴즈 세션 완료", description = "퀴즈 세션을 완료 처리합니다")
+    public ResponseEntity<Map<String, Object>> completeSession(
+            @Parameter(description = "세션 ID") @PathVariable Long sessionId) {
+        quizSessionCommandService.completeSession(sessionId);
+
+        // 성공 응답 생성
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("message", "Quiz session completed successfully");
+        response.put("sessionId", sessionId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/api/dto/AnswerRequest.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/AnswerRequest.java
@@ -1,0 +1,15 @@
+package com._1.spring_rest_api.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerRequest {
+
+    private String userAnswer;
+}

--- a/src/main/java/com/_1/spring_rest_api/api/dto/AnswerResponse.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/AnswerResponse.java
@@ -1,0 +1,19 @@
+package com._1.spring_rest_api.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerResponse {
+
+    private Boolean isCorrect;
+    private String correctAnswer;
+    private Boolean isComplete;
+    private Integer nextQuestionIndex;
+    private QuestionResponse nextQuestion;
+}

--- a/src/main/java/com/_1/spring_rest_api/api/dto/QuizSessionDetailResponse.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/QuizSessionDetailResponse.java
@@ -1,0 +1,30 @@
+package com._1.spring_rest_api.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizSessionDetailResponse {
+    private Long id;
+    private Long quizId;
+    private String quizTitle;
+    private String quizDescription;
+    private Integer totalQuestions;
+    private Integer currentQuestionIndex;
+    private QuestionResponse currentQuestion;
+    private Boolean completed;
+    private Integer score;
+    private Integer totalQuestionsAnswered;
+    private Integer totalCorrectAnswers;
+    private List<UserAnswerResponse> userAnswers;
+    private LocalDateTime createdAt;
+    private LocalDateTime completedAt;
+}

--- a/src/main/java/com/_1/spring_rest_api/api/dto/QuizSessionResponse.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/QuizSessionResponse.java
@@ -1,0 +1,23 @@
+package com._1.spring_rest_api.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizSessionResponse {
+
+    private Long id;
+    private Long quizId;
+    private String quizTitle;
+    private Integer currentQuestionIndex;
+    private Boolean completed;
+    private LocalDateTime createdAt;
+    private LocalDateTime completedAt;
+}

--- a/src/main/java/com/_1/spring_rest_api/api/dto/UserAnswerResponse.java
+++ b/src/main/java/com/_1/spring_rest_api/api/dto/UserAnswerResponse.java
@@ -1,0 +1,23 @@
+package com._1.spring_rest_api.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAnswerResponse {
+
+    private Long id;
+    private Long questionId;
+    private String questionFront;
+    private String userAnswer;
+    private String correctAnswer;
+    private Boolean isCorrect;
+    private LocalDateTime answeredAt;
+}

--- a/src/main/java/com/_1/spring_rest_api/converter/AnswerResponseConverter.java
+++ b/src/main/java/com/_1/spring_rest_api/converter/AnswerResponseConverter.java
@@ -1,0 +1,36 @@
+package com._1.spring_rest_api.converter;
+
+import com._1.spring_rest_api.api.dto.AnswerResponse;
+import com._1.spring_rest_api.api.dto.QuestionResponse;
+import com._1.spring_rest_api.entity.Question;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AnswerResponseConverter {
+
+    private final QuestionConverter questionConverter;
+
+    /**
+     * 사용자 답변 결과를 AnswerResponse DTO로 변환
+     */
+    public AnswerResponse toDto(
+            boolean isCorrect,
+            String correctAnswer,
+            Question nextQuestion,
+            int nextQuestionIndex,
+            boolean isComplete) {
+
+        // 다음 질문이 있으면 DTO로 변환
+        QuestionResponse nextQuestionResponse = questionConverter.toDto(nextQuestion);
+
+        return AnswerResponse.builder()
+                .isCorrect(isCorrect)
+                .correctAnswer(correctAnswer)
+                .isComplete(isComplete)
+                .nextQuestionIndex(nextQuestionIndex)
+                .nextQuestion(nextQuestionResponse)
+                .build();
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/converter/QuestionConverter.java
+++ b/src/main/java/com/_1/spring_rest_api/converter/QuestionConverter.java
@@ -1,0 +1,39 @@
+package com._1.spring_rest_api.converter;
+
+import com._1.spring_rest_api.api.dto.QuestionResponse;
+import com._1.spring_rest_api.entity.Question;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QuestionConverter implements Converter<Question, QuestionResponse> {
+
+    @Override
+    public QuestionResponse toDto(Question entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return QuestionResponse.builder()
+                .id(entity.getId())
+                .weekId(entity.getWeek() != null ? entity.getWeek().getId() : null)
+                .front(entity.getFront())
+                .back(entity.getBack())
+                .build();
+    }
+
+    @Override
+    public Question toEntity(QuestionResponse dto) {
+        if (dto == null) {
+            return null;
+        }
+
+        return Question.builder()
+                .id(dto.getId())
+                .front(dto.getFront())
+                .back(dto.getBack())
+                .build();
+        // 주의: week 등 연관관계는 별도로 설정해야 함
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/converter/QuizSessionConverter.java
+++ b/src/main/java/com/_1/spring_rest_api/converter/QuizSessionConverter.java
@@ -1,0 +1,28 @@
+package com._1.spring_rest_api.converter;
+
+import com._1.spring_rest_api.api.dto.QuizSessionResponse;
+import com._1.spring_rest_api.entity.QuizSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QuizSessionConverter implements Converter<QuizSession, QuizSessionResponse> {
+    @Override
+    public QuizSessionResponse toDto(QuizSession entity) {
+        return QuizSessionResponse.builder()
+                .id(entity.getId())
+                .quizId(entity.getQuiz().getId())
+                .quizTitle(entity.getQuiz().getTitle())
+                .currentQuestionIndex(entity.getCurrentQuestionIndex())
+                .completed(entity.getCompleted())
+                .createdAt(entity.getCreateAt())
+                .completedAt(entity.getCompletedAt())
+                .build();
+    }
+
+    @Override
+    public QuizSession toEntity(QuizSessionResponse dto) {
+        return null;
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/converter/QuizSessionDetailConverter.java
+++ b/src/main/java/com/_1/spring_rest_api/converter/QuizSessionDetailConverter.java
@@ -1,0 +1,47 @@
+package com._1.spring_rest_api.converter;
+
+import com._1.spring_rest_api.api.dto.QuestionResponse;
+import com._1.spring_rest_api.api.dto.QuizSessionDetailResponse;
+import com._1.spring_rest_api.api.dto.UserAnswerResponse;
+import com._1.spring_rest_api.entity.CustomQuiz;
+import com._1.spring_rest_api.entity.Question;
+import com._1.spring_rest_api.entity.QuizSession;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class QuizSessionDetailConverter{
+
+    public QuizSessionDetailResponse toDto(QuizSession session, List<UserAnswerResponse> userAnswers) {
+        CustomQuiz quiz = session.getQuiz();
+
+        // 현재 질문 응답 객체 생성
+        QuestionResponse currentQuestion = getCurrentQuestionResponse(session);
+
+        return QuizSessionDetailResponse.builder()
+                .id(session.getId())
+                .quizId(quiz.getId())
+                .quizTitle(quiz.getTitle())
+                .quizDescription(quiz.getDescription())
+                .totalQuestions(quiz.getTotalQuestions())
+                .currentQuestionIndex(session.getCurrentQuestionIndex())
+                .currentQuestion(currentQuestion)
+                .completed(session.getCompleted())
+                .userAnswers(userAnswers)
+                .createdAt(session.getCreateAt())
+                .completedAt(session.getCompletedAt())
+                .build();
+    }
+
+    private QuestionResponse getCurrentQuestionResponse(QuizSession session) {
+        CustomQuiz quiz = session.getQuiz();
+        int currentIndex = session.getCurrentQuestionIndex();
+
+        if (currentIndex < quiz.getQuizQuestionMappings().size()) {
+            Question question = quiz.getQuizQuestionMappings().get(currentIndex).getQuestion();
+            return question.toQuestionResponse();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/converter/UserAnswerConverter.java
+++ b/src/main/java/com/_1/spring_rest_api/converter/UserAnswerConverter.java
@@ -1,0 +1,29 @@
+package com._1.spring_rest_api.converter;
+
+import com._1.spring_rest_api.api.dto.UserAnswerResponse;
+import com._1.spring_rest_api.entity.UserAnswer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserAnswerConverter implements Converter<UserAnswer, UserAnswerResponse> {
+
+    @Override
+    public UserAnswerResponse toDto(UserAnswer entity) {
+        return UserAnswerResponse.builder()
+                .id(entity.getId())
+                .questionId(entity.getQuestion().getId())
+                .questionFront(entity.getQuestion().getFront())
+                .userAnswer(entity.getUserAnswer())
+                .correctAnswer(entity.getQuestion().getBack())
+                .isCorrect(entity.getIsCorrect())
+                .answeredAt(entity.getAnsweredAt())
+                .build();
+    }
+
+    @Override
+    public UserAnswer toEntity(UserAnswerResponse dto) {
+        return null;
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/entity/Question.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/Question.java
@@ -90,4 +90,8 @@ public class Question extends BaseTimeEntity {
                 .back(this.back) // 필드명 변경
                 .build();
     }
+
+    public boolean isCorrectAnswer(String answer) {
+        return this.back.trim().equalsIgnoreCase(answer.trim());
+    }
 }

--- a/src/main/java/com/_1/spring_rest_api/entity/QuizSession.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/QuizSession.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "QUIZ_SESSION")
 @Getter
@@ -29,8 +31,79 @@ public class QuizSession extends BaseTimeEntity {
     @JoinColumn(name = "quiz_id")
     private CustomQuiz quiz;
 
-    @Column(name = "current_question_index")
     private Integer currentQuestionIndex;
+
+    private Boolean completed;
+
+    private LocalDateTime completedAt;
+
+    public static QuizSession create(User user, CustomQuiz quiz) {
+        if (user == null) {
+            throw new IllegalArgumentException("사용자는 null이 될 수 없습니다");
+        }
+        if (quiz == null) {
+            throw new IllegalArgumentException("퀴즈는 null이 될 수 없습니다");
+        }
+
+        return QuizSession.builder()
+                .user(user)
+                .quiz(quiz)
+                .currentQuestionIndex(0)
+                .completed(false)
+                .build();
+    }
+
+    public void moveToNextQuestion() {
+        this.currentQuestionIndex++;
+    }
+
+    public void recordAnswer() {
+        // 점수 관리 없이 단순히 다음 문제로 이동
+        moveToNextQuestion();
+    }
+
+    public void completeSession() {
+        this.completed = true;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    // QuizSession 클래스에 추가
+    public Question getCurrentQuestion() {
+        if (this.currentQuestionIndex >= this.quiz.getQuizQuestionMappings().size()) {
+            return null;
+        }
+        return this.quiz.getQuizQuestionMappings().get(this.currentQuestionIndex).getQuestion();
+    }
+
+    public Question getNextQuestion() {
+        int nextIndex = this.currentQuestionIndex + 1;
+        if (nextIndex < this.quiz.getQuizQuestionMappings().size()) {
+            return this.quiz.getQuizQuestionMappings().get(nextIndex).getQuestion();
+        }
+        return null;
+    }
+
+    public boolean isComplete() {
+        return this.currentQuestionIndex >= this.quiz.getQuizQuestionMappings().size();
+    }
+
+    public UserAnswer createAnswer(String userAnswerText) {
+        Question currentQuestion = getCurrentQuestion();
+        if (currentQuestion == null) {
+            throw new IllegalStateException("세션에 현재 질문이 없습니다");
+        }
+
+        boolean isCorrect = currentQuestion.isCorrectAnswer(userAnswerText);
+
+        return UserAnswer.builder()
+                .user(this.user)
+                .question(currentQuestion)
+                .userAnswer(userAnswerText)
+                .isCorrect(isCorrect)
+                .attemptCount(1)
+                .answeredAt(LocalDateTime.now())
+                .build();
+    }
 
     // User와 QuizSession 간의 양방향 연관관계 메서드
     public void changeUser(User user) {

--- a/src/main/java/com/_1/spring_rest_api/entity/SupplementalFile.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/SupplementalFile.java
@@ -33,7 +33,6 @@ public class SupplementalFile extends BaseTimeEntity {
     @Column(name = "file_type")
     private String fileType;
 
-    // SupplementalFile.java에 추가
     public void changeWeek(Week week) {
         this.week = week;
         if (week != null && !week.getSupplementalFiles().contains(this)) {

--- a/src/main/java/com/_1/spring_rest_api/repository/QuizSessionRepository.java
+++ b/src/main/java/com/_1/spring_rest_api/repository/QuizSessionRepository.java
@@ -2,6 +2,50 @@ package com._1.spring_rest_api.repository;
 
 import com._1.spring_rest_api.entity.QuizSession;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> {
+
+    /**
+     * 특정 사용자의 모든 퀴즈 세션을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 퀴즈 세션 목록
+     */
+    @Query("SELECT s FROM QuizSession s WHERE s.user.id = :userId ORDER BY s.createAt DESC")
+    List<QuizSession> findAllByUserId(@Param("userId") Long userId);
+
+    /**
+     * 특정 퀴즈의 모든 세션을 조회합니다.
+     *
+     * @param quizId 퀴즈 ID
+     * @return 퀴즈 세션 목록
+     */
+    @Query("SELECT s FROM QuizSession s WHERE s.quiz.id = :quizId ORDER BY s.createAt DESC")
+    List<QuizSession> findAllByQuizId(@Param("quizId") Long quizId);
+
+    /**
+     * 특정 사용자가 특정 퀴즈에 대해 생성한 모든 세션을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @param quizId 퀴즈 ID
+     * @return 퀴즈 세션 목록
+     */
+    @Query("SELECT s FROM QuizSession s WHERE s.user.id = :userId AND s.quiz.id = :quizId ORDER BY s.createAt DESC")
+    List<QuizSession> findAllByUserIdAndQuizId(@Param("userId") Long userId, @Param("quizId") Long quizId);
+
+    /**
+     * 특정 사용자의 완료된 세션만 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @param completed 완료 여부
+     * @return 퀴즈 세션 목록
+     */
+    @Query("SELECT s FROM QuizSession s WHERE s.user.id = :userId AND s.completed = :completed ORDER BY s.createAt DESC")
+    List<QuizSession> findAllByUserIdAndCompleted(@Param("userId") Long userId, @Param("completed") Boolean completed);
 }

--- a/src/main/java/com/_1/spring_rest_api/repository/UserAnswerRepository.java
+++ b/src/main/java/com/_1/spring_rest_api/repository/UserAnswerRepository.java
@@ -1,0 +1,29 @@
+package com._1.spring_rest_api.repository;
+
+import com._1.spring_rest_api.entity.UserAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+@Repository
+public interface UserAnswerRepository extends JpaRepository<UserAnswer, Long> {
+
+    /**
+     * 특정 사용자의 모든 답변을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 사용자 답변 목록
+     */
+    @Query("SELECT a FROM UserAnswer a WHERE a.user.id = :userId ORDER BY a.answeredAt DESC")
+    List<UserAnswer> findAllByUserId(@Param("userId") Long userId);
+
+
+    @Query("SELECT ua FROM UserAnswer ua WHERE ua.user.id = :userId AND ua.question.id IN :questionIds")
+    List<UserAnswer> findByUserIdAndQuestionIdIn(
+            @Param("userId") Long userId,
+            @Param("questionIds") Collection<Long> questionIds);
+}

--- a/src/main/java/com/_1/spring_rest_api/service/QuizCommandService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizCommandService.java
@@ -7,4 +7,6 @@ public interface QuizCommandService {
     Long createQuiz(CreateQuizRequest request);
 
     void deleteQuiz(Long quizId);
+
+    Long startQuizSession(Long quizId, Long userId);
 }

--- a/src/main/java/com/_1/spring_rest_api/service/QuizCommandServiceImpl.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizCommandServiceImpl.java
@@ -55,6 +55,31 @@ public class QuizCommandServiceImpl implements QuizCommandService{
         customQuizRepository.deleteById(quizId);
     }
 
+    @Override
+    public Long startQuizSession(Long quizId, Long userId) {
+        // 퀴즈 및 사용자 존재 확인
+        CustomQuiz quiz = customQuizRepository.findById(quizId)
+                .orElseThrow(() -> new EntityNotFoundException("Quiz not found with id: " + quizId));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userId));
+
+        // 새 퀴즈 세션 생성
+        QuizSession session = QuizSession.builder()
+                .user(user)
+                .quiz(quiz)
+                .currentQuestionIndex(0) // 첫 번째 질문부터 시작
+                .build();
+
+        // 양방향 연관관계 설정
+        session.changeUser(user);
+        session.changeQuiz(quiz);
+
+        // 저장 및 ID 반환
+        QuizSession savedSession = quizSessionRepository.save(session);
+        return savedSession.getId();
+    }
+
     // 주차와 퀴즈 연결
     private void connectWeeksToQuiz(List<Long> weekIds, CustomQuiz quiz) {
         if (weekIds == null || weekIds.isEmpty()) {

--- a/src/main/java/com/_1/spring_rest_api/service/QuizSessionCommandService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizSessionCommandService.java
@@ -1,0 +1,11 @@
+package com._1.spring_rest_api.service;
+
+import com._1.spring_rest_api.api.dto.AnswerRequest;
+import com._1.spring_rest_api.api.dto.AnswerResponse;
+
+public interface QuizSessionCommandService {
+
+    AnswerResponse answerQuestion(Long sessionId, AnswerRequest request);
+
+    void completeSession(Long sessionId);
+}

--- a/src/main/java/com/_1/spring_rest_api/service/QuizSessionCommandServiceImpl.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizSessionCommandServiceImpl.java
@@ -1,0 +1,79 @@
+package com._1.spring_rest_api.service;
+
+import com._1.spring_rest_api.api.dto.AnswerRequest;
+import com._1.spring_rest_api.api.dto.AnswerResponse;
+import com._1.spring_rest_api.converter.AnswerResponseConverter;
+import com._1.spring_rest_api.converter.QuestionConverter;
+import com._1.spring_rest_api.entity.CustomQuiz;
+import com._1.spring_rest_api.entity.Question;
+import com._1.spring_rest_api.entity.QuizSession;
+import com._1.spring_rest_api.entity.UserAnswer;
+import com._1.spring_rest_api.repository.QuizSessionRepository;
+import com._1.spring_rest_api.repository.UserAnswerRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizSessionCommandServiceImpl implements QuizSessionCommandService {
+
+    private final QuizSessionRepository quizSessionRepository;
+    private final UserAnswerRepository userAnswerRepository;
+    private final QuestionConverter questionConverter;
+    private final AnswerResponseConverter answerResponseConverter;
+
+    @Override
+    public AnswerResponse answerQuestion(Long sessionId, AnswerRequest request) {
+        // 1. 세션 조회
+        QuizSession session = findSessionById(sessionId);
+
+        // 2. 현재 질문 확인
+        Question currentQuestion = session.getCurrentQuestion();
+        if (currentQuestion == null) {
+            throw new EntityNotFoundException("Session Id not found" + sessionId);
+        }
+
+        // 3. 사용자 답변 생성 및 저장
+        UserAnswer userAnswer = session.createAnswer(request.getUserAnswer());
+        userAnswer.changeUser(session.getUser());
+        userAnswer.changeQuestion(currentQuestion);
+        userAnswerRepository.save(userAnswer);
+
+        // 4. 세션 상태 업데이트
+        session.recordAnswer();
+        quizSessionRepository.save(session);
+
+        // 5. 응답 생성 및 반환
+        Question nextQuestion = session.getNextQuestion();
+        return answerResponseConverter.toDto(
+                userAnswer.getIsCorrect(),
+                currentQuestion.getBack(),
+                nextQuestion,
+                session.getCurrentQuestionIndex(),
+                session.isComplete()
+        );
+    }
+
+    @Override
+    public void completeSession(Long sessionId) {
+        QuizSession session = findSessionById(sessionId);
+
+        if (!session.getCompleted()) {
+            session.completeSession();
+            quizSessionRepository.save(session);
+        }
+    }
+
+    /**
+     * ID로 퀴즈 세션 조회
+     */
+    private QuizSession findSessionById(Long sessionId) {
+        return quizSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new EntityNotFoundException("Session not found with id: " + sessionId));
+    }
+}

--- a/src/main/java/com/_1/spring_rest_api/service/QuizSessionQueryService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizSessionQueryService.java
@@ -1,0 +1,13 @@
+package com._1.spring_rest_api.service;
+
+import com._1.spring_rest_api.api.dto.QuizSessionDetailResponse;
+import com._1.spring_rest_api.api.dto.QuizSessionResponse;
+
+import java.util.List;
+
+public interface QuizSessionQueryService {
+
+    List<QuizSessionResponse> getUserQuizSessions(Long userId);
+
+    QuizSessionDetailResponse getSessionDetail(Long sessionId);
+}

--- a/src/main/java/com/_1/spring_rest_api/service/QuizSessionQueryServiceImpl.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizSessionQueryServiceImpl.java
@@ -1,0 +1,74 @@
+package com._1.spring_rest_api.service;
+
+import com._1.spring_rest_api.api.dto.QuizSessionDetailResponse;
+import com._1.spring_rest_api.api.dto.QuizSessionResponse;
+import com._1.spring_rest_api.api.dto.UserAnswerResponse;
+import com._1.spring_rest_api.converter.QuizSessionConverter;
+import com._1.spring_rest_api.converter.QuizSessionDetailConverter;
+import com._1.spring_rest_api.converter.UserAnswerConverter;
+import com._1.spring_rest_api.entity.CustomQuiz;
+import com._1.spring_rest_api.entity.QuizSession;
+import com._1.spring_rest_api.entity.UserAnswer;
+import com._1.spring_rest_api.repository.QuizSessionRepository;
+import com._1.spring_rest_api.repository.UserAnswerRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizSessionQueryServiceImpl implements QuizSessionQueryService {
+
+    private final QuizSessionRepository quizSessionRepository;
+    private final UserAnswerRepository userAnswerRepository;
+    private final QuizSessionConverter quizSessionConverter;
+    private final UserAnswerConverter userAnswerConverter;
+    private final QuizSessionDetailConverter quizSessionDetailConverter;
+
+    @Override
+    public List<QuizSessionResponse> getUserQuizSessions(Long userId) {
+        List<QuizSession> sessions = quizSessionRepository.findAllByUserId(userId);
+
+        return sessions.stream()
+                .map(quizSessionConverter::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public QuizSessionDetailResponse getSessionDetail(Long sessionId) {
+        QuizSession session = quizSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new EntityNotFoundException("Session not found with id: " + sessionId));
+
+        List<UserAnswerResponse> userAnswerResponses = getUserAnswersForSession(session);
+
+        return quizSessionDetailConverter.toDto(session, userAnswerResponses);
+    }
+
+    private List<UserAnswerResponse> getUserAnswersForSession(QuizSession session) {
+        CustomQuiz quiz = session.getQuiz();
+        Long userId = session.getUser().getId();
+
+        // 퀴즈에 포함된 질문 ID 집합 추출
+        Set<Long> quizQuestionIds = getQuizQuestionIds(quiz);
+
+        List<UserAnswer> userAnswers = userAnswerRepository.findByUserIdAndQuestionIdIn(
+                userId, quizQuestionIds);
+
+        // DTO로 변환
+        return userAnswers.stream()
+                .map(userAnswerConverter::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private Set<Long> getQuizQuestionIds(CustomQuiz quiz) {
+        return quiz.getQuizQuestionMappings().stream()
+                .map(mapping -> mapping.getQuestion().getId())
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
## 🔍 개요
<!-- 이 PR이 무엇을 위한 것인지 간략하게 설명해주세요 -->
유저가 각 퀴즈의 세션을 관리하는 API를 구현했습니다.

## 📝 변경사항
<!-- 주요 변경사항을 불릿 포인트로 나열해주세요 -->
- 사용자별 퀴즈 세션 목록 조회 API 구현
- 퀴즈 세션 상세 조회 API 구현
- 질문 답변 API 구현
- 퀴즈 세션 완료 API 구현

close #36 