### PR TITLE
[Fix] 카카오 로그인 리다이렉트 경로가 https로 접근하도록 변경

### DIFF
--- a/src/main/java/com/_1/spring_rest_api/api/controller/AuthController.java
+++ b/src/main/java/com/_1/spring_rest_api/api/controller/AuthController.java
@@ -3,6 +3,7 @@ package com._1.spring_rest_api.api.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,6 +14,9 @@ import org.springframework.web.servlet.view.RedirectView;
 @Tag(name = "인증 API", description = "사용자 인증 관련 API")
 public class AuthController {
 
+    @Value("${api.server.url}")
+    private String serverApiUrl;
+
     @GetMapping("/kakao")
     @Operation(
             summary = "카카오 OAuth2 로그인",
@@ -21,7 +25,7 @@ public class AuthController {
     @SecurityRequirements
     public RedirectView kakaoLogin() {
         RedirectView redirectView = new RedirectView();
-        redirectView.setUrl("/oauth2/authorization/kakao");
+        redirectView.setUrl(serverApiUrl + "/oauth2/authorization/kakao");
         return redirectView;
     }
 }

--- a/src/main/java/com/_1/spring_rest_api/config/SecurityConfig.java
+++ b/src/main/java/com/_1/spring_rest_api/config/SecurityConfig.java
@@ -28,11 +28,11 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                                .anyRequest().permitAll()
-//                        .requestMatchers("/", "/login", "/oauth2/**", "/api/public/auth/**", "/error",
-//                                "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**",
-//                                "/swagger-resources/**", "/webjars/**", "/api/v1/**").permitAll()
-//                        .anyRequest().authenticated()
+//                                .anyRequest().permitAll()
+                        .requestMatchers("/", "/login", "/oauth2/**", "/api/public/auth/**", "/error",
+                                "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**",
+                                "/swagger-resources/**", "/webjars/**", "/api/v1/**").permitAll()
+                        .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .successHandler(oAuth2SuccessHandler)


### PR DESCRIPTION
## 🔍 개요
<!-- 이 PR이 무엇을 위한 것인지 간략하게 설명해주세요 -->
카카오 로그인 리다이렉트 경로가 https로 접근하도록 변경했습니다.

@Value 어노테이션을 통해 가져온 값으로 상대경로에서 직접경로로 변경했습니다.