### PR TITLE
[Fix] QuizSession 조회 시 여러 UserAnswer가 오는 문제 해결

### DIFF
--- a/src/main/java/com/_1/spring_rest_api/entity/QuizSession.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/QuizSession.java
@@ -101,12 +101,14 @@ public class QuizSession extends BaseTimeEntity {
         UserAnswer userAnswer = UserAnswer.builder()
                 .user(this.user)
                 .question(currentQuestion)
+                .quizSession(this)
                 .userAnswer(userAnswerText)
                 .isCorrect(isCorrect)
                 .attemptCount(1)
                 .answeredAt(LocalDateTime.now())
                 .build();
 
+        this.addUserAnswer(userAnswer);
         currentQuestion.addUserAnswer(userAnswer);
         this.user.addUserAnswer(userAnswer);
 

--- a/src/main/java/com/_1/spring_rest_api/entity/QuizSession.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/QuizSession.java
@@ -4,11 +4,14 @@ package com._1.spring_rest_api.entity;
 import com._1.spring_rest_api.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "QUIZ_SESSION")
@@ -31,6 +34,10 @@ public class QuizSession extends BaseTimeEntity {
     @JoinColumn(name = "quiz_id")
     private CustomQuiz quiz;
 
+    @OneToMany(mappedBy = "quizSession", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<UserAnswer> userAnswers = new ArrayList<>();
+
     private Integer currentQuestionIndex;
 
     private Boolean completed;
@@ -50,6 +57,20 @@ public class QuizSession extends BaseTimeEntity {
         this.quiz = quiz;
         if (quiz != null && !quiz.getQuizSessions().contains(this)) {
             quiz.getQuizSessions().add(this);
+        }
+    }
+
+    public void addUserAnswer(UserAnswer userAnswer) {
+        this.userAnswers.add(userAnswer);
+        if (userAnswer.getQuizSession() != this) {
+            userAnswer.changeQuizSession(this);
+        }
+    }
+
+    public void removeUserAnswer(UserAnswer userAnswer) {
+        this.userAnswers.remove(userAnswer);
+        if (userAnswer.getQuizSession() == this) {
+            userAnswer.changeQuizSession(null);
         }
     }
 

--- a/src/main/java/com/_1/spring_rest_api/entity/UserAnswer.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/UserAnswer.java
@@ -31,6 +31,10 @@ public class UserAnswer extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_session_id")
+    private QuizSession quizSession; // 추가
+
     @Column(name = "user_answer", columnDefinition = "TEXT")
     private String userAnswer;
 
@@ -56,6 +60,13 @@ public class UserAnswer extends BaseTimeEntity {
         this.question = question;
         if (question != null && !question.getUserAnswers().contains(this)) {
             question.getUserAnswers().add(this);
+        }
+    }
+
+    public void changeQuizSession(QuizSession quizSession) {
+        this.quizSession = quizSession;
+        if (quizSession != null && !quizSession.getUserAnswers().contains(this)) {
+            quizSession.getUserAnswers().add(this);
         }
     }
 }

--- a/src/main/java/com/_1/spring_rest_api/repository/UserAnswerRepository.java
+++ b/src/main/java/com/_1/spring_rest_api/repository/UserAnswerRepository.java
@@ -12,18 +12,6 @@ import java.util.List;
 @Repository
 public interface UserAnswerRepository extends JpaRepository<UserAnswer, Long> {
 
-    /**
-     * 특정 사용자의 모든 답변을 조회합니다.
-     *
-     * @param userId 사용자 ID
-     * @return 사용자 답변 목록
-     */
-    @Query("SELECT a FROM UserAnswer a WHERE a.user.id = :userId ORDER BY a.answeredAt DESC")
-    List<UserAnswer> findAllByUserId(@Param("userId") Long userId);
-
-
-    @Query("SELECT ua FROM UserAnswer ua WHERE ua.user.id = :userId AND ua.question.id IN :questionIds")
-    List<UserAnswer> findByUserIdAndQuestionIdIn(
-            @Param("userId") Long userId,
-            @Param("questionIds") Collection<Long> questionIds);
+    @Query("SELECT ua FROM UserAnswer ua WHERE ua.quizSession.id = :sessionId ORDER BY ua.answeredAt ASC")
+    List<UserAnswer> findByQuizSessionIdOrderByAnsweredAt(@Param("sessionId") Long sessionId);
 }

--- a/src/main/java/com/_1/spring_rest_api/service/QuizSessionQueryServiceImpl.java
+++ b/src/main/java/com/_1/spring_rest_api/service/QuizSessionQueryServiceImpl.java
@@ -45,30 +45,17 @@ public class QuizSessionQueryServiceImpl implements QuizSessionQueryService {
         QuizSession session = quizSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new EntityNotFoundException("Session not found with id: " + sessionId));
 
-        List<UserAnswerResponse> userAnswerResponses = getUserAnswersForSession(session);
+        List<UserAnswerResponse> userAnswerResponses = getUserAnswersForSession(sessionId);
 
         return quizSessionDetailConverter.toDto(session, userAnswerResponses);
     }
 
-    private List<UserAnswerResponse> getUserAnswersForSession(QuizSession session) {
-        CustomQuiz quiz = session.getQuiz();
-        Long userId = session.getUser().getId();
-
-        // 퀴즈에 포함된 질문 ID 집합 추출
-        Set<Long> quizQuestionIds = getQuizQuestionIds(quiz);
-
-        List<UserAnswer> userAnswers = userAnswerRepository.findByUserIdAndQuestionIdIn(
-                userId, quizQuestionIds);
+    private List<UserAnswerResponse> getUserAnswersForSession(Long sessionId) {
+        List<UserAnswer> userAnswers = userAnswerRepository.findByQuizSessionIdOrderByAnsweredAt(sessionId);
 
         // DTO로 변환
         return userAnswers.stream()
                 .map(userAnswerConverter::toDto)
                 .collect(Collectors.toList());
-    }
-
-    private Set<Long> getQuizQuestionIds(CustomQuiz quiz) {
-        return quiz.getQuizQuestionMappings().stream()
-                .map(mapping -> mapping.getQuestion().getId())
-                .collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
## 🔍 개요
<!-- 이 PR이 무엇을 위한 것인지 간략하게 설명해주세요 -->
QuizSession 조회 시 QuestionId로 조회해 문제가 발생했습니다.
이를 해결합니다.

## 📝 변경사항
<!-- 주요 변경사항을 불릿 포인트로 나열해주세요 -->
- QuizSession과 UserAnswer를 일대다 관계로 매핑
- 답변 저장 시 QuizSession 정보 저장
- 세션 조회 시 SessionId로 조회하도록 변경

close #73 