### PR TITLE
[Fix] JPA Auditing으로 생성되는 createdAt 필드가 null로 저장되는 문제 해결

### DIFF
--- a/src/main/java/com/_1/spring_rest_api/entity/base/BaseTimeEntity.java
+++ b/src/main/java/com/_1/spring_rest_api/entity/base/BaseTimeEntity.java
@@ -22,7 +22,7 @@ import java.time.LocalDateTime;
 public abstract class BaseTimeEntity {
 
     @CreatedDate
-    @Column(updatable = false, insertable = false)
+    @Column(updatable = false)
     private LocalDateTime createAt;
 
     @LastModifiedDate


### PR DESCRIPTION
## 🔍 개요
<!-- 이 PR이 무엇을 위한 것인지 간략하게 설명해주세요 -->
@CreatedDate가 붙은 createAt 필드에 insertable=false가 설정되어 있어서 JPA Auditing이 동작하지 않고 모든 레코드의 createdAt이 null로 저장됨


## 📝 변경사항
<!-- 주요 변경사항을 불릿 포인트로 나열해주세요 -->
- insertable=false 옵션을 제거하여 JPA Auditing이 정상 동작하도록 수정

close #81 