### PR TITLE
[Fix] AI JSON 응답 파싱 에러 해결

### DIFF
--- a/src/main/java/com/_1/spring_rest_api/service/ClaudeService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/ClaudeService.java
@@ -195,6 +195,8 @@ public class ClaudeService {
                   \\}>
                   ...
                 ]
+                7. 응답은 반드시 순수한 JSON 배열 형태로만 제공해주세요.
+                8. markdown 코드 블록이나 추가 설명 없이 JSON만 반환해주세요.
                 """.formatted(minQuestionCount);
 
         Message systemMessage = new SystemMessage(systemPrompt);
@@ -209,7 +211,6 @@ public class ClaudeService {
             ChatResponse response = chatModel.call(prompt);
             String responseContent = response.getResult().getOutput().getText();
 
-            // 마크다운 코드 블록 제거 <- 이 부분 추가!
             String cleanJsonString = cleanJsonResponse(responseContent);
 
             // JSON 파싱

--- a/src/main/java/com/_1/spring_rest_api/service/ClaudeService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/ClaudeService.java
@@ -214,7 +214,7 @@ public class ClaudeService {
 
             // JSON 파싱
             return objectMapper.readValue(
-                    responseContent,
+                    cleanJsonString,
                     new TypeReference<List<QuestionDto>>() {}
             );
         } catch (Exception e) {

--- a/src/main/java/com/_1/spring_rest_api/service/ClaudeService.java
+++ b/src/main/java/com/_1/spring_rest_api/service/ClaudeService.java
@@ -223,14 +223,32 @@ public class ClaudeService {
     }
 
     private String cleanJsonResponse(String response) {
-        // ```json과 ``` 제거
+        if (response == null || response.trim().isEmpty()) {
+            throw new IllegalArgumentException("AI 응답이 비어있습니다.");
+        }
+
         String cleaned = response.trim();
 
-        // 다양한 마크다운 패턴 처리
-        cleaned = cleaned.replaceAll("^```(json)?\\s*", ""); // 시작 부분
-        cleaned = cleaned.replaceAll("\\s*```$", "");        // 끝 부분
+        // markdown 코드 블록 제거 (```json과 ```)
+        if (cleaned.startsWith("```json")) {
+            cleaned = cleaned.substring(7); // "```json" 제거
+        } else if (cleaned.startsWith("```")) {
+            cleaned = cleaned.substring(3); // "```" 제거
+        }
 
-        return cleaned.trim();
+        if (cleaned.endsWith("```")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 3); // 마지막 "```" 제거
+        }
+
+        // 앞뒤 공백 제거
+        cleaned = cleaned.trim();
+
+        // JSON 유효성 기본 검증
+        if (!cleaned.startsWith("[") && !cleaned.startsWith("{")) {
+            throw new IllegalArgumentException("유효하지 않은 JSON 형식입니다: " + cleaned.substring(0, Math.min(100, cleaned.length())));
+        }
+
+        return cleaned;
     }
 
     private String generateSummationByClaude(Long textId, String text) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=spring-rest-api
 spring.profiles.include=secret
 
 # \u00EC\u0084\u009C\u00EB\u00B2\u0084 \u00EC\u0084\u00A4\u00EC\u00A0\u0095
-server.port=8081
+server.port=8080
 
 # JPA \u00EC\u0084\u00A4\u00EC\u00A0\u0095
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=spring-rest-api
 spring.profiles.include=secret
 
 # \u00EC\u0084\u009C\u00EB\u00B2\u0084 \u00EC\u0084\u00A4\u00EC\u00A0\u0095
-server.port=8080
+server.port=8081
 
 # JPA \u00EC\u0084\u00A4\u00EC\u00A0\u0095
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## 🔍 개요
<!-- 이 PR이 무엇을 위한 것인지 간략하게 설명해주세요 -->
AI 모델이 JSON을 markdown 코드 블록(````json```)으로 감싸서 반환할 때, Jackson ObjectMapper가 파싱하지 못해 JsonParseException이 발생하여 애플리케이션이 크래시됩니다.


## 📝 변경사항
<!-- 주요 변경사항을 불릿 포인트로 나열해주세요 -->
해결 방안
- JSON 정리 유틸리티 강화
- AI 프롬프트 개선
- 순수 JSON 형식을 명시적으로 요청

변경 사항
✅ ClaudeService.java: JSON 정리 메서드 사용하도록 변경
✅ ClaudeService.java: generateQuestionsFromContent() 메서드 업데이트
✅ 더 나은 응답 형식을 위한 AI 프롬프트 업데이트